### PR TITLE
fix(LazyAPI): `TShockAPI.I18n.TranslationCultureInfo`为空时, 无法正确生成配置

### DIFF
--- a/src/LazyAPI/ConfigFiles/JsonConfigBase.cs
+++ b/src/LazyAPI/ConfigFiles/JsonConfigBase.cs
@@ -34,7 +34,11 @@ public abstract class JsonConfigBase<T> where T : JsonConfigBase<T>, new()
         "TranslationCultureInfo",
         BindingFlags.NonPublic | BindingFlags.Static)!.GetValue(null)!
         };
-
+        
+        if (string.IsNullOrEmpty(cultureInfo.Name))
+        {
+            cultureInfo = new CultureInfo("en-US");
+        } 
         _settings = new JsonSerializerSettings()
         {
             ContractResolver = new CultureContractResolver(cultureInfo),

--- a/src/LazyAPI/PluginContainer.cs
+++ b/src/LazyAPI/PluginContainer.cs
@@ -10,7 +10,7 @@ public class PluginContainer : LazyPlugin
 {
     public override string Author => "cc004 & members of UnrealMultiple";
 
-    public override Version Version => new Version(1, 0, 0, 9);
+    public override Version Version => new Version(1, 0, 1, 0);
 
     public PluginContainer(Main game) : base(game) { }
     public override void Initialize()

--- a/src/LazyAPI/README.en-US.md
+++ b/src/LazyAPI/README.en-US.md
@@ -6,25 +6,6 @@
 
 ## Command line parameters
 - `-culture zh|en` This command line parameter is used to switch the language for generating configuration files. By default, it follows the ts language.
-## Change log
-
-```
-v1.0.0.6
-Database/DB.cs toolset sets tableName as optional
-Add configuration file reload prompt
-
-v1.0.0.4
-Support Spanish, Russian
-
-V1.0.0.2
-Supports generating default configurations, supporting multiple languages ​​and more operations!
-
-v1.0.0.1
-Initial support for multi-language configuration files
-
-v1.0.0.0
-initial upload
-```
 
 ## Feedback
 - Github Issue -> TShockPlugin Repo: https://github.com/UnrealMultiple/TShockPlugin

--- a/src/LazyAPI/README.md
+++ b/src/LazyAPI/README.md
@@ -9,8 +9,12 @@
 ## 更新日志
 
 ```
+v1.0.1.0
+修复`TShockAPI.I18n.TranslationCultureInfo`为空时, 无法正确生成配置
+
 v1.0.0.7
 添加游戏进度工具类
+
 v1.0.0.6
 Database/DB.cs 工具集设置 tableName 为可选
 添加配置文件重载提示


### PR DESCRIPTION
### 更新插件/修复BUG
- [ ] 插件已修改版本号
- [ ] 更新插件README.md中的更新日志
- [ ] 插件可以正常工作
### 其他
- [ ] ❤️熙恩我喜欢你
