### PR TITLE
update：tpallow存起来

### DIFF
--- a/src/EssentialsPlus/Commands.cs
+++ b/src/EssentialsPlus/Commands.cs
@@ -632,6 +632,27 @@ public static class Commands
         }
     }
 
+    public static void TpAllow(CommandArgs e)
+    {
+        try
+        {
+            if (EssentialsPlus.TpAllows.ToggleTpAllow(e.Player))
+            {
+                bool isEnabled = EssentialsPlus.TpAllows.IsTpAllowed(e.Player);
+                string status = isEnabled ? GetString("允许") : GetString("禁止");
+                e.Player.SendSuccessMessage(GetString("您的传送状态已切换为：{0}"), status);
+            }
+            else
+            {
+                e.Player.SendErrorMessage(GetString("无法切换传送状态，请查看日志获取更多信息。"));
+            }
+        }
+        catch (Exception ex)
+        {
+            TShock.Log.Error($"TpAllow command error for {e.Player.Name}: {ex}");
+            e.Player.SendErrorMessage(GetString("命令执行失败，请稍后重试。"));
+        }
+    }
 
     public static void PvP(CommandArgs e)
     {

--- a/src/EssentialsPlus/Commands.cs
+++ b/src/EssentialsPlus/Commands.cs
@@ -638,8 +638,8 @@ public static class Commands
         {
             if (EssentialsPlus.TpAllows.ToggleTpAllow(e.Player))
             {
-                bool isEnabled = EssentialsPlus.TpAllows.IsTpAllowed(e.Player);
-                string status = isEnabled ? GetString("允许") : GetString("禁止");
+                var isEnabled = EssentialsPlus.TpAllows.IsTpAllowed(e.Player);
+                var status = isEnabled ? GetString("允许") : GetString("禁止");
                 e.Player.SendSuccessMessage(GetString("您的传送状态已切换为：{0}"), status);
             }
             else

--- a/src/EssentialsPlus/Db/TpAllowManager.cs
+++ b/src/EssentialsPlus/Db/TpAllowManager.cs
@@ -131,7 +131,7 @@ public class TpAllowManager
             using var result = this.db.QueryReader("SELECT IsEnabled FROM TpAllows WHERE Name = @0", player.Name);
             if (result.Read())
             {
-                bool isEnabled = result.Get<bool>("IsEnabled");
+                var isEnabled = result.Get<bool>("IsEnabled");
                 this.TpAllows.Add(new TpAllow(player.Name, isEnabled));
                 player.TPAllow = isEnabled;
                 return isEnabled;

--- a/src/EssentialsPlus/Db/TpAllowManager.cs
+++ b/src/EssentialsPlus/Db/TpAllowManager.cs
@@ -1,0 +1,147 @@
+﻿using MySql.Data.MySqlClient;
+using System.Data;
+using TShockAPI;
+using TShockAPI.DB;
+
+namespace EssentialsPlus.Db;
+
+public class TpAllowManager
+{
+    public class TpAllow
+    {
+        public string Name { get; set; }
+        public bool IsEnabled { get; set; }
+
+        public TpAllow(string name, bool isEnabled)
+        {
+            this.Name = name;
+            this.IsEnabled = isEnabled;
+        }
+    }
+
+    private readonly IDbConnection db;
+    private readonly List<TpAllow> TpAllows = new();
+
+    public TpAllowManager(IDbConnection db)
+    {
+        this.db = db;
+        var sqlCreator = new SqlTableCreator(db, db.GetSqlQueryBuilder());
+        sqlCreator.EnsureTableStructure(new SqlTable("TpAllows",
+            new SqlColumn("Name", MySqlDbType.Text) { Primary = true },
+            new SqlColumn("IsEnabled", MySqlDbType.Int32)));
+
+        using var result = db.QueryReader("SELECT * FROM TpAllows");
+        while (result.Read())
+        {
+            this.TpAllows.Add(new TpAllow(
+                result.Get<string>("Name"),
+                result.Get<bool>("IsEnabled")));
+        }
+    }
+
+    public bool ToggleTpAllow(TSPlayer player)
+    {
+        try
+        {
+            var existing = this.TpAllows.Find(f => f.Name == player.Name);
+            bool newState;
+
+            if (existing == null)
+            {
+                newState = true;
+                this.TpAllows.Add(new TpAllow(player.Name, newState));
+
+                if (this.db.Query("INSERT OR REPLACE INTO TpAllows VALUES (@0, @1)",
+                    player.Name, newState ? 1 : 0) > 0)
+                {
+                    player.TPAllow = newState;
+                    return true;
+                }
+                return false;
+            }
+            else
+            {
+                newState = !existing.IsEnabled;
+                existing.IsEnabled = newState;
+
+                if (this.db.Query("UPDATE TpAllows SET IsEnabled = @0 WHERE Name = @1",
+                    newState ? 1 : 0, player.Name) > 0)
+                {
+                    player.TPAllow = newState;
+                    return true;
+                }
+                return false;
+            }
+        }
+        catch (Exception ex)
+        {
+            TShock.Log.Error($"ToggleTpAllow error for {player.Name}: {ex}");
+            return false;
+        }
+    }
+
+    public bool SetTpAllow(TSPlayer player, bool isEnabled)
+    {
+        try
+        {
+            var existing = this.TpAllows.Find(f => f.Name == player.Name);
+
+            if (existing == null)
+            {
+                this.TpAllows.Add(new TpAllow(player.Name, isEnabled));
+
+                if (this.db.Query("INSERT OR REPLACE INTO TpAllows VALUES (@0, @1)",
+                    player.Name, isEnabled ? 1 : 0) > 0)
+                {
+                    player.TPAllow = isEnabled;
+                    return true;
+                }
+                return false;
+            }
+            else
+            {
+                existing.IsEnabled = isEnabled;
+                if (this.db.Query("UPDATE TpAllows SET IsEnabled = @0 WHERE Name = @1",
+                    isEnabled ? 1 : 0, player.Name) > 0)
+                {
+                    player.TPAllow = isEnabled;
+                    return true;
+                }
+                return false;
+            }
+        }
+        catch (Exception ex)
+        {
+            TShock.Log.Error($"SetTpAllow error for {player.Name}: {ex}");
+            return false;
+        }
+    }
+
+    public bool IsTpAllowed(TSPlayer player)
+    {
+        var record = this.TpAllows.Find(f => f.Name == player.Name);
+        if (record != null)
+        {
+            player.TPAllow = record.IsEnabled;
+            return record.IsEnabled;
+        }
+
+        try
+        {
+            using var result = this.db.QueryReader("SELECT IsEnabled FROM TpAllows WHERE Name = @0", player.Name);
+            if (result.Read())
+            {
+                bool isEnabled = result.Get<bool>("IsEnabled");
+                this.TpAllows.Add(new TpAllow(player.Name, isEnabled));
+                player.TPAllow = isEnabled;
+                return isEnabled;
+            }
+        }
+        catch (Exception ex)
+        {
+            TShock.Log.Error($"查询玩家 {player.Name} 的传送权限时发生错误: {ex}");
+        }
+        player.TPAllow = false;
+        return false;
+    }
+}

--- a/src/EssentialsPlus/Db/TpAllowManager.cs
+++ b/src/EssentialsPlus/Db/TpAllowManager.cs
@@ -27,7 +27,7 @@ public class TpAllowManager
         this.db = db;
         var sqlCreator = new SqlTableCreator(db, db.GetSqlQueryBuilder());
         sqlCreator.EnsureTableStructure(new SqlTable("TpAllows",
-            new SqlColumn("Name", MySqlDbType.Text) { Primary = true },
+            new SqlColumn("Name", MySqlDbType.Text),
             new SqlColumn("IsEnabled", MySqlDbType.Int32)));
 
         using var result = db.QueryReader("SELECT * FROM TpAllows");

--- a/src/EssentialsPlus/Permissions.cs
+++ b/src/EssentialsPlus/Permissions.cs
@@ -11,6 +11,7 @@ public static class Permissions
     public static readonly string LastCommand = "essentials.lastcommand";
     public static readonly string More = "essentials.more";
     public static readonly string Mute = "essentials.mute";
+    public static readonly string TpAllow = "essentials.tpallow";
     public static readonly string PvP = "essentials.pvp";
     public static readonly string Ruler = "essentials.ruler";
     public static readonly string Send = "essentials.send";

--- a/src/EssentialsPlus/README.en-US.md
+++ b/src/EssentialsPlus/README.en-US.md
@@ -24,6 +24,7 @@
     - **add** `<name> <time>` -> Mutes the player `<name>` for the duration `<time>`.
     - **delete** `<name>` -> Removes the mute for the player `<name>`.
     - **help** -> Displays command info.
+- **/tpallow** -> Improved /tpallow command.
 - **/pvpget** -> Enables or disables your PvP status.
 - **/ruler** `[1|2]` -> Measures the distance between points 1 and 2.
 - **/sudo** `[flag] <player> <command>` -> Makes `<player>` execute `<command>`. Valid flag: `-force` -> Forces the player to run the command, ignoring permission checks. Players with the `essentials.sudo.super` permission can use /sudo on anyone.
@@ -44,6 +45,7 @@
 - `essentials.lastcommand` -> Grants access to the `/=` command.
 - `essentials.more` -> Grants access to the `/more` command.
 - `essentials.mute` -> Grants access to the improved `/mute` command.
+- `essentials.tpallow` -> Grants access to the improved `/tpallow` command.
 - `essentials.pvp` -> Grants access to the `/pvpget` command.
 - `essentials.ruler` -> Grants access to the `/ruler` command.
 - `essentials.send` -> Grants access to the `/send` command.

--- a/src/EssentialsPlus/README.es-ES.md
+++ b/src/EssentialsPlus/README.es-ES.md
@@ -23,6 +23,7 @@
   - **add** `<nombre> <tiempo>` -> Silencia al jugador `<nombre>` por el tiempo `<tiempo>`.
   - **delete** `<nombre>` -> Quita el silencio del jugador `<nombre>`.
   - **help** -> Muestra información del comando.
+- **/tpallow** -> Comando mejorado `/tpallow`.
 - **/pvpget** -> Activa o desactiva tu estado de PvP.
 - **/ruler** `[1|2]` -> Mide la distancia entre los puntos 1 y 2.
 - **/sudo** `[flag] <jugador> <comando>` -> Hace que `<jugador>` ejecute `<comando>`. Bandera válida: `-force` -> Obliga al jugador a ejecutar el comando, ignorando las verificaciones de permisos. Los jugadores con el permiso `essentials.sudo.super` pueden usar `/sudo` en cualquier persona.
@@ -43,6 +44,7 @@
 - `essentials.lastcommand` -> Permite el uso del comando `/=`.
 - `essentials.more` -> Permite el uso del comando `/more`.
 - `essentials.mute` -> Permite el uso del comando mejorado `/mute`.
+- `essentials.tpallow` -> Permite el uso del comando mejorado `/tpallow`.
 - `essentials.pvp` -> Permite el uso del comando `/pvpget`.
 - `essentials.ruler` -> Permite el uso del comando `/ruler`.
 - `essentials.send` -> Permite el uso del comando `/send`.

--- a/src/EssentialsPlus/README.md
+++ b/src/EssentialsPlus/README.md
@@ -23,6 +23,7 @@
     - **add** `<名称> <时间>` -> 为名称为 `<名称>` 的用户添加静音，时间为 `<时间>`。
     - **delete** `<名称>` -> 删除名称为 `<名称>` 的用户的静音。
     - **help** 或 **帮助** -> 输出命令信息。
+- **/tpallow** -> 改进的 /tpallow 命令。
 - **/pvpget** 或 **/切换PvP状态** -> 切换您的 PvP 状态。
 - **/ruler** 或 **/测量工具** `[1|2]` -> 测量点 1 和点 2 之间的距离。
 - **/sudo** 或 **/代执行** `[flag] <玩家> <命令>` -> 让 `<玩家>` 执行 `<命令>`。有效标志：`-force` -> 强制执行命令，忽略 `<玩家>` 的权限限制。拥有 `essentials.sudo.super` 权限的玩家可以对任何人使用 /sudo。
@@ -43,6 +44,7 @@
 - `essentials.lastcommand` -> 授予访问 `/=` 命令的权限。
 - `essentials.more` -> 授予访问 `/more` 命令的权限。
 - `essentials.mute` -> 授予访问改进后的 `/mute` 命令的权限。
+- `essentials.tpallow` -> 授予访问改进后的 `/tpallow` 命令的权限。
 - `essentials.pvp` -> 授予访问 `/pvpget` 命令的权限。
 - `essentials.ruler` -> 授予访问 `/ruler` 命令的权限。
 - `essentials.send` -> 授予访问 `/send` 命令的权限。
@@ -74,6 +76,8 @@
 
 ## 更新日志
 ```
+1.0.9
+tpallow存起来
 1.0.7
 EssentialsPlus的config使用lazyapi，禁言判断uuid，名字，ip
 1.0.4

--- a/src/EssentialsPlus/README.md
+++ b/src/EssentialsPlus/README.md
@@ -77,7 +77,7 @@
 ## 更新日志
 ```
 1.0.9
-tpallow存起来
+数据库记录玩家tpallow状态
 1.0.7
 EssentialsPlus的config使用lazyapi，禁言判断uuid，名字，ip
 1.0.4


### PR DESCRIPTION
### 更新插件/修复BUG
- [x] 插件已修改版本号
- [x] 更新插件README.md中的更新日志
- [x] 插件可以正常工作
### 其他
- [x] ❤️Cai喵我喜欢你

好的，这是将拉取请求摘要翻译成中文的结果：

## Sourcery 总结

添加持久传送权限功能，将其集成到玩家加入和命令处理中，增强静音-取消静音逻辑，更新版本和文档

新功能：
- 引入 TpAllowManager 和新的数据库表来持久化每个玩家的传送权限状态
- 添加 /tpallow 命令来切换和报告玩家的传送权限

增强功能：
- 在玩家加入时加载并应用存储的传送权限，并提供调试/错误日志记录
- 改进加入时的静音处理，采用强大的取消逻辑和详细的日志记录

文档：
- 更新所有支持语言的 README，以记录改进后的 /tpallow 命令和相关权限

杂项：
- 将插件版本提升至 1.0.9

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add persistent teleport permission feature, integrate it into player join and command handling, enhance mute-unmute logic, update version and documentation

New Features:
- Introduce TpAllowManager and new database table to persist per-player teleport permission status
- Add /tpallow command to toggle and report players' teleport permission

Enhancements:
- Load and apply stored teleport permission on player join with debug/error logging
- Refine mute handling on join with robust cancellation logic and detailed logging

Documentation:
- Update README in all supported languages to document the improved /tpallow command and related permission

Chores:
- Bump plugin version to 1.0.9

</details>