### PR TITLE
chore(workflow): 更新子模块后不跳过CI，提交消息中包含更新的子模块

### DIFF
--- a/.github/workflows/update_submodules.yml
+++ b/.github/workflows/update_submodules.yml
@@ -23,10 +23,18 @@ jobs:
           git pull
           git submodule update --init
           git submodule update --remote
+          
+          changed_submodules=$(git submodule foreach --quiet 'git diff --quiet --exit-code || echo $name')
+          
           git add .
           if git diff --staged --quiet; then
             echo "跳过更新：子模块没有变化"
           else
-            git commit -m "自动更新子模块 [skip ci]"
+            if [ -n "$changed_submodules" ]; then
+              submodule_list=$(echo "$changed_submodules" | sort -u | tr '\n' ',' | sed 's/,$//')
+              git commit -m "chore: 自动更新子模块$submodule_list"
+            else
+              git commit -m "chore: 自动更新子模块"
+            fi
             git push
           fi

--- a/.github/workflows/update_submodules.yml
+++ b/.github/workflows/update_submodules.yml
@@ -24,7 +24,7 @@ jobs:
           git submodule update --init
           git submodule update --remote
           
-          changed_submodules=$(git submodule foreach --quiet 'git diff --quiet --exit-code || echo $name')
+          changed_submodules=$(git diff --cached --name-only | grep -oP 'src/Submodules/\K[^/]+' | sort -u)
           
           git add .
           if git diff --staged --quiet; then


### PR DESCRIPTION
### 其他
- [x] ❤️熙恩我喜欢你

## Sourcery 总结

改进子模块更新工作流，使其始终运行 CI 并用更新的子模块名称标注提交消息。

CI:
- 移除 skip-ci 标记，以在子模块更新后始终触发 CI
- 检测已更改的子模块，并将其名称附加到自动化提交消息中

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve submodule update workflow to always run CI and annotate commit messages with updated submodule names

CI:
- Remove skip-ci flag to always trigger CI after submodule updates
- Detect changed submodules and append their names to the automated commit message

</details>