### PR TITLE
fix(CaiBotLite): 修复无法正确识别骷髅王的问题, 死亡计数被覆盖, 卸载Reload和KillMe事件

### DIFF
--- a/src/CaiBotLite/CaiBotLite.cs
+++ b/src/CaiBotLite/CaiBotLite.cs
@@ -15,7 +15,7 @@ namespace CaiBotLite;
 // ReSharper disable once ClassNeverInstantiated.Global
 public class CaiBotLite(Main game) : TerrariaPlugin(game)
 {
-    public static readonly Version VersionNum = new (2025, 08, 3, 0); //日期+版本号(0,1,2...)
+    public static readonly Version VersionNum = new (2025, 08, 5, 0); //日期+版本号(0,1,2...)
     internal static int InitCode = -1;
     internal static bool DebugMode = Program.LaunchParameters.ContainsKey("-caidebug");
     private const string CharacterInfoKey = "CaiBotLite.CharacterInfo";
@@ -40,7 +40,7 @@ public class CaiBotLite(Main game) : TerrariaPlugin(game)
         Hooks.MessageBuffer.InvokeGetData += Login.MessageBuffer_InvokeGetData; 
         GeneralHooks.ReloadEvent += GeneralHooksOnReloadEvent;
         PlayerHooks.PlayerPostLogin += PlayerHooksOnPlayerPostLogin;
-        GetDataHandlers.KillMe += KillMe;
+        GetDataHandlers.KillMe.Register(KillMe, HandlerPriority.Highest);
         MapGenerator.Init();
         EconomicSupport.Init();
         BossLockSupport.Init();

--- a/src/CaiBotLite/CaiBotLite.cs
+++ b/src/CaiBotLite/CaiBotLite.cs
@@ -61,7 +61,9 @@ public class CaiBotLite(Main game) : TerrariaPlugin(game)
             ServerApi.Hooks.ServerLeave.Deregister(this, OnServerLeave);
             ServerApi.Hooks.GamePostUpdate.Deregister(this, OnGameUpdate);
             Hooks.MessageBuffer.InvokeGetData -= Login.MessageBuffer_InvokeGetData;
+            GeneralHooks.ReloadEvent -= GeneralHooksOnReloadEvent;
             PlayerHooks.PlayerPostLogin -= PlayerHooksOnPlayerPostLogin;
+            GetDataHandlers.KillMe.UnRegister(KillMe);
             MapGenerator.Dispose();
             WebsocketManager.StopWebsocket();
         }

--- a/src/CaiBotLite/README.md
+++ b/src/CaiBotLite/README.md
@@ -33,6 +33,9 @@ https://docs.terraria.ink/zh/caibot/CaiBotLite.html
 
 ## 更新日志
 
+### v2025.08.05.0
+- 提高KillMe优先级，以正常记录死亡次数
+- 修复无法正确识别骷髅王的问题
 ### v2025.08.03.0
 - 修复在线排行数据错误，优化Websocket处理，适配BossLock
 

--- a/src/CaiBotLite/Services/BossLockSupport.cs
+++ b/src/CaiBotLite/Services/BossLockSupport.cs
@@ -35,7 +35,7 @@ public static class BossLockSupport
             { NPCID.BrainofCthulhu, "Brain of Cthulhu" },
             { NPCID.QueenBee, "Queen Bee" },
             { NPCID.Deerclops, "Deerclops" },
-            { NPCID.SkeletronHead, "Skeletron" },
+            { NPCID.SkeletronHand, "Skeletron" },
             { NPCID.WallofFlesh, "Wall of Flesh" },
             { NPCID.QueenSlimeBoss, "Queen Slime" },
             { NPCID.Retinazer, "The Twins" },


### PR DESCRIPTION
### 更新插件/修复BUG
- [x] 插件已修改版本号
- [x] 更新插件README.md中的更新日志
- [x] 插件可以正常工作
### 其他
- [x] ❤️熙恩我喜欢你

## Sourcery 总结

将插件版本提升至 v2025.08.05.0，修复骷髅王检测，确保 KillMe 死亡计数处理器以最高优先级运行并正确注销，并更新更新日志。

错误修复：
- 通过映射到 NPCID.SkeletronHand 修复不正确的骷髅王检测
- 通过提高 KillMe 处理器优先级并添加正确的注册和注销来防止死亡计数被覆盖

改进：
- 将插件版本号提升至 2025.08.05.0
- 在 Dispose 中添加 Reload 和 KillMe 事件的注销

文档：
- 更新 README 更新日志至 2025.08.05.0 版本

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bump plugin to v2025.08.05.0, fix Skeletron detection, ensure KillMe death count handler runs at highest priority with proper unregistration, and update changelog.

Bug Fixes:
- Fix incorrect Skeletron detection by mapping to NPCID.SkeletronHand
- Prevent death counts from being overwritten by increasing KillMe handler priority and adding proper registration and unregistration

Enhancements:
- Bump plugin version number to 2025.08.05.0
- Add deregistration of Reload and KillMe events in Dispose

Documentation:
- Update README changelog for version 2025.08.05.0

</details>