### PR TITLE
LazyAPI更新

### DIFF
--- a/src/AdditionalPylons/AdditionalPylonsPlugin.cs
+++ b/src/AdditionalPylons/AdditionalPylonsPlugin.cs
@@ -1,4 +1,5 @@
 ﻿using LazyAPI;
+using LazyAPI.Hooks;
 using Terraria;
 using Terraria.GameContent;
 using Terraria.GameContent.NetModules;
@@ -34,10 +35,10 @@ public class AdditionalPylonsPlugin : LazyPlugin
     #region Plugin Overrides
     public override void Initialize()
     {
+        this.addHooks.Add(GetDataHandlers.PlayerUpdate.GetHook(this.OnPlayerUpdate));
+        this.addHooks.Add(GetDataHandlers.PlaceTileEntity.GetHook(this.OnPlaceTileEntity, HandlerPriority.High));
+        this.addHooks.Add(GetDataHandlers.SendTileRect.GetHook(this.OnSendTileRect, HandlerPriority.High));
         base.Initialize();
-        GetDataHandlers.PlayerUpdate.Register(this.OnPlayerUpdate);
-        GetDataHandlers.PlaceTileEntity.Register(this.OnPlaceTileEntity, HandlerPriority.High);
-        GetDataHandlers.SendTileRect.Register(this.OnSendTileRect, HandlerPriority.High);
     }
     #endregion
     #region [IDisposable Implementation]
@@ -53,9 +54,6 @@ public class AdditionalPylonsPlugin : LazyPlugin
 
         if (isDisposing)
         {
-            GetDataHandlers.PlayerUpdate.UnRegister(this.OnPlayerUpdate);
-            GetDataHandlers.PlaceTileEntity.UnRegister(this.OnPlaceTileEntity);
-            GetDataHandlers.SendTileRect.UnRegister(this.OnSendTileRect);
         }
 
         base.Dispose(isDisposing);

--- a/src/AdditionalPylons/AdditionalPylonsPlugin.cs
+++ b/src/AdditionalPylons/AdditionalPylonsPlugin.cs
@@ -34,6 +34,7 @@ public class AdditionalPylonsPlugin : LazyPlugin
     #region Plugin Overrides
     public override void Initialize()
     {
+        base.Initialize();
         GetDataHandlers.PlayerUpdate.Register(this.OnPlayerUpdate);
         GetDataHandlers.PlaceTileEntity.Register(this.OnPlaceTileEntity, HandlerPriority.High);
         GetDataHandlers.SendTileRect.Register(this.OnSendTileRect, HandlerPriority.High);

--- a/src/AnnouncementBoxPlus/Plugin.cs
+++ b/src/AnnouncementBoxPlus/Plugin.cs
@@ -1,4 +1,5 @@
 ﻿using LazyAPI;
+using LazyAPI.Hooks;
 using Microsoft.Xna.Framework;
 using On.OTAPI;
 using System.Globalization;
@@ -36,22 +37,10 @@ public class AnnouncementBoxPlus : LazyPlugin
     //插件加载时执行的代码
     public override void Initialize()
     {
+        this.addHooks.Add(new ActionHook(() => On.OTAPI.Hooks.Wiring.InvokeAnnouncementBox += this.OnAnnouncementBox));
+        this.addHooks.Add(GetDataHandlers.SignRead.GetHook(this.OnSignRead));
+        this.addHooks.Add(GetDataHandlers.Sign.GetHook(this.OnSign));
         base.Initialize();
-        On.OTAPI.Hooks.Wiring.InvokeAnnouncementBox += this.OnAnnouncementBox;
-        GetDataHandlers.SignRead.Register(this.OnSignRead);
-        GetDataHandlers.Sign.Register(this.OnSign);
-    }
-
-    protected override void Dispose(bool disposing)
-    {
-        if (disposing)
-        {
-            GetDataHandlers.SignRead.UnRegister(this.OnSignRead);
-            GetDataHandlers.Sign.UnRegister(this.OnSign);
-            On.OTAPI.Hooks.Wiring.InvokeAnnouncementBox -= this.OnAnnouncementBox;
-        }
-
-        base.Dispose(disposing);
     }
 
     private void OnSign(object? sender, GetDataHandlers.SignEventArgs e)

--- a/src/AnnouncementBoxPlus/Plugin.cs
+++ b/src/AnnouncementBoxPlus/Plugin.cs
@@ -36,6 +36,7 @@ public class AnnouncementBoxPlus : LazyPlugin
     //插件加载时执行的代码
     public override void Initialize()
     {
+        base.Initialize();
         On.OTAPI.Hooks.Wiring.InvokeAnnouncementBox += this.OnAnnouncementBox;
         GetDataHandlers.SignRead.Register(this.OnSignRead);
         GetDataHandlers.Sign.Register(this.OnSign);

--- a/src/AutoAirItem/AutoAirItem.cs
+++ b/src/AutoAirItem/AutoAirItem.cs
@@ -28,8 +28,9 @@ public class AutoAirItem : LazyPlugin
         }
         GetDataHandlers.PlayerUpdate.Register(this.OnPlayerUpdate);
         ServerApi.Hooks.NetGreetPlayer.Register(this, this.OnGreetPlayer);
-        TShockAPI.Commands.ChatCommands.Add(new Command("AutoAir.use", Commands.AirCmd, "air", "垃圾"));
-        TShockAPI.Commands.ChatCommands.Add(new Command("AutoAir.admin", Commands.Reset, "airreset", "重置垃圾桶"));
+        this.addCommands.Add(new Command("AutoAir.use", Commands.AirCmd, "air", "垃圾"));
+        this.addCommands.Add(new Command("AutoAir.admin", Commands.Reset, "airreset", "重置垃圾桶"));
+        base.Initialize();
     }
 
     protected override void Dispose(bool disposing)
@@ -38,8 +39,6 @@ public class AutoAirItem : LazyPlugin
         {
             GetDataHandlers.PlayerUpdate.UnRegister(this.OnPlayerUpdate);
             ServerApi.Hooks.NetGreetPlayer.Deregister(this, this.OnGreetPlayer);
-            TShockAPI.Commands.ChatCommands.RemoveAll(x => x.CommandDelegate == Commands.AirCmd);
-            TShockAPI.Commands.ChatCommands.RemoveAll(x => x.CommandDelegate == Commands.Reset);
         }
         base.Dispose(disposing);
     }

--- a/src/AutoBroadcast/AutoBroadcast.cs
+++ b/src/AutoBroadcast/AutoBroadcast.cs
@@ -21,6 +21,7 @@ public class AutoBroadcast : LazyPlugin
 
     public override void Initialize()
     {
+        base.Initialize();
         ServerApi.Hooks.GameUpdate.Register(this, this.OnUpdate);
         ServerApi.Hooks.ServerChat.Register(this, OnChat, int.MinValue); //最低优先级，这样不需要处理命令
     }

--- a/src/AutoClear/AutoClear.cs
+++ b/src/AutoClear/AutoClear.cs
@@ -20,6 +20,7 @@ public class AutoClear(Main game) : LazyPlugin(game)
 
     public override void Initialize()
     {
+        base.Initialize();
         ServerApi.Hooks.GameUpdate.Register(this, this.OnUpdate);
     }
     

--- a/src/AutoFish/AutoFish.cs
+++ b/src/AutoFish/AutoFish.cs
@@ -28,7 +28,8 @@ public class AutoFish : LazyPlugin
         ServerApi.Hooks.ServerJoin.Register(this, this.OnJoin);
         GetDataHandlers.PlayerUpdate.Register(this.OnPlayerUpdate);
         ServerApi.Hooks.ProjectileAIUpdate.Register(this, this.ProjectAiUpdate);
-        TShockAPI.Commands.ChatCommands.Add(new Command("autofish", Commands.Afs, "af", "autofish"));
+        this.addCommands.Add(new Command("autofish", Commands.Afs, "af", "autofish"));
+        base.Initialize();
     }
 
     protected override void Dispose(bool disposing)
@@ -40,7 +41,6 @@ public class AutoFish : LazyPlugin
             ServerApi.Hooks.ServerJoin.Deregister(this, this.OnJoin);
             GetDataHandlers.PlayerUpdate.UnRegister(this.OnPlayerUpdate);
             ServerApi.Hooks.ProjectileAIUpdate.Deregister(this, this.ProjectAiUpdate);
-            TShockAPI.Commands.ChatCommands.RemoveAll(x => x.CommandDelegate == Commands.Afs);
         }
         base.Dispose(disposing);
     }

--- a/src/AutoReset/AutoResetPlugin.cs
+++ b/src/AutoReset/AutoResetPlugin.cs
@@ -33,14 +33,15 @@ public class AutoResetPlugin(Main game) : LazyPlugin(game)
 
     public override void Initialize()
     {
-        Commands.ChatCommands.Add(new Command("reset.admin", this.ResetCmd, "reset", "重置世界"));
-        Commands.ChatCommands.Add(new Command("reset.admin", this.ResetDataCmd, "resetdata", "重置数据"));
-        Commands.ChatCommands.Add(new Command(this.OnWho, "who", "playing", "online"));
-        Commands.ChatCommands.Add(new Command("reset.admin", this.ResetSetting, "rs", "重置设置"));
+        this.addCommands.Add(new Command("reset.admin", this.ResetCmd, "reset", "重置世界"));
+        this.addCommands.Add(new Command("reset.admin", this.ResetDataCmd, "resetdata", "重置数据"));
+        this.addCommands.Add(new Command(this.OnWho, "who", "playing", "online"));
+        this.addCommands.Add(new Command("reset.admin", this.ResetSetting, "rs", "重置设置"));
         ServerApi.Hooks.ServerJoin.Register(this, this.OnServerJoin, int.MaxValue);
         ServerApi.Hooks.WorldSave.Register(this, this.OnWorldSave, int.MaxValue);
         ServerApi.Hooks.NpcKilled.Register(this, this.CountKill);
         Terraria.Utils.TryCreatingDirectory(this._replaceFilePath);
+        base.Initialize();
     }
 
     private void ResetDataCmd(CommandArgs args)
@@ -53,7 +54,6 @@ public class AutoResetPlugin(Main game) : LazyPlugin(game)
     {
         if (disposing)
         {
-            Commands.ChatCommands.RemoveAll(c => c.CommandDelegate == this.ResetCmd || c.CommandDelegate == this.OnWho || c.CommandDelegate == this.ResetSetting);
             ServerApi.Hooks.NpcKilled.Deregister(this, this.CountKill);
             ServerApi.Hooks.ServerJoin.Deregister(this, this.OnServerJoin);
             ServerApi.Hooks.WorldSave.Deregister(this, this.OnWorldSave);

--- a/src/AutoStoreItems/AutoStoreItems.cs
+++ b/src/AutoStoreItems/AutoStoreItems.cs
@@ -22,8 +22,9 @@ public class AutoStoreItems : LazyPlugin
     {
         ServerApi.Hooks.ServerJoin.Register(this, this.OnJoin);
         GetDataHandlers.PlayerUpdate.Register(this.OnPlayerUpdate);
-        TShockAPI.Commands.ChatCommands.Add(new Command("AutoStore.use", Commands.Ast, "ast", "自存"));
-        TShockAPI.Commands.ChatCommands.Add(new Command("AutoStore.admin", Commands.Reset, "astreset", "重置自存"));
+        this.addCommands.Add(new Command("AutoStore.use", Commands.Ast, "ast", "自存"));
+        this.addCommands.Add(new Command("AutoStore.admin", Commands.Reset, "astreset", "重置自存"));
+        base.Initialize();
     }
 
 
@@ -33,8 +34,6 @@ public class AutoStoreItems : LazyPlugin
         {
             ServerApi.Hooks.ServerJoin.Deregister(this, this.OnJoin);
             GetDataHandlers.PlayerUpdate.UnRegister(this.OnPlayerUpdate);
-            TShockAPI.Commands.ChatCommands.RemoveAll(x => x.CommandDelegate == Commands.Ast);
-            TShockAPI.Commands.ChatCommands.RemoveAll(x => x.CommandDelegate == Commands.Reset);
         }
         base.Dispose(disposing);
     }

--- a/src/AutoTeam/AutoTeamPlus.cs
+++ b/src/AutoTeam/AutoTeamPlus.cs
@@ -23,7 +23,8 @@ public class AutoTeam : LazyPlugin
         ServerApi.Hooks.NetGreetPlayer.Register(this, this.OnJoin);
         PlayerHooks.PlayerPostLogin += this.OnLogin;
         GetDataHandlers.PlayerTeam += this.Team;
-        Commands.ChatCommands.Add(new Command("autoteam.toggle", this.TogglePlugin, "autoteam", "at"));
+        this.addCommands.Add(new Command("autoteam.toggle", this.TogglePlugin, "autoteam", "at"));
+        base.Initialize();
     }
 
     protected override void Dispose(bool disposing)
@@ -33,7 +34,6 @@ public class AutoTeam : LazyPlugin
             ServerApi.Hooks.NetGreetPlayer.Deregister(this, this.OnJoin);
             PlayerHooks.PlayerPostLogin -= this.OnLogin;
             GetDataHandlers.PlayerTeam -= this.Team;
-            Commands.ChatCommands.RemoveAll(x => x.CommandDelegate == this.TogglePlugin);
         }
         base.Dispose(disposing);
     }

--- a/src/Back/BackPlugin.cs
+++ b/src/Back/BackPlugin.cs
@@ -25,11 +25,12 @@ public class BackPlugin : LazyPlugin
         ServerApi.Hooks.NetGreetPlayer.Register(this, this.OnPlayerJoin);
         GetDataHandlers.KillMe += this.OnDead;
 
-        Commands.ChatCommands.Add(new Command("back", this.Back, "back")
+        this.addCommands.Add(new Command("back", this.Back, "back")
         {
             HelpText = GetString("返回最后一次死亡的位置"),
             AllowServer = false
         });
+        base.Initialize();
     }
 
     protected override void Dispose(bool disposing)
@@ -39,7 +40,6 @@ public class BackPlugin : LazyPlugin
             ServerApi.Hooks.ServerLeave.Deregister(this, this.ResetPos);
             ServerApi.Hooks.NetGreetPlayer.Deregister(this, this.OnPlayerJoin);
             GetDataHandlers.KillMe -= this.OnDead;
-            Commands.ChatCommands.RemoveAll(x => x.CommandDelegate == this.Back);
         }
 
         base.Dispose(disposing);

--- a/src/BanNpc/Plugin.cs
+++ b/src/BanNpc/Plugin.cs
@@ -22,15 +22,15 @@ public class Plugin : LazyPlugin
 
     public override void Initialize()
     {
-        Commands.ChatCommands.Add(new Command("bannpc.use", this.BanCommand, "bm"));
+        this.addCommands.Add(new Command("bannpc.use", this.BanCommand, "bm"));
         ServerApi.Hooks.NpcSpawn.Register(this, this.OnSpawn);
         ServerApi.Hooks.NpcTransform.Register(this, this.OnTransform);
+        base.Initialize();
     }
     protected override void Dispose(bool disposing)
     {
         if (disposing)
         {
-            Commands.ChatCommands.RemoveAll(x => x.CommandDelegate == this.BanCommand);
             ServerApi.Hooks.NpcSpawn.Deregister(this, this.OnSpawn);
             ServerApi.Hooks.NpcTransform.Deregister(this, this.OnTransform);
         }

--- a/src/BedSet/Plugin.cs
+++ b/src/BedSet/Plugin.cs
@@ -19,7 +19,8 @@ public class Plugin : LazyPlugin
     public override void Initialize()
     {
         GetDataHandlers.PlayerSpawn.Register(this.OnSpawn);
-        Commands.ChatCommands.Add(new("bed.spawn.set", this.CBed, "家", "shome"));
+        this.addCommands.Add(new("bed.spawn.set", this.CBed, "家", "shome"));
+        base.Initialize();
     }
 
     private void CBed(CommandArgs args)
@@ -54,7 +55,6 @@ public class Plugin : LazyPlugin
     {
         if (disposing)
         {
-            Commands.ChatCommands.RemoveAll(x => x.CommandDelegate == this.CBed);
             GetDataHandlers.PlayerSpawn.UnRegister(this.OnSpawn);
         }
         base.Dispose(disposing);

--- a/src/BetterWhitelist/Main.cs
+++ b/src/BetterWhitelist/Main.cs
@@ -20,7 +20,8 @@ public class BetterWhitelist : LazyPlugin
     public override void Initialize()
     {
         ServerApi.Hooks.ServerJoin.Register(this, this.OnJoin);
-        Commands.ChatCommands.Add(new Command("bwl.use", this.BetterWhitelistCommand, "bwl"));
+        this.addCommands.Add(new Command("bwl.use", this.BetterWhitelistCommand, "bwl"));
+        base.Initialize();
     }
 
     private void OnJoin(JoinEventArgs args)
@@ -42,7 +43,6 @@ public class BetterWhitelist : LazyPlugin
         if (disposing)
         {
             ServerApi.Hooks.ServerJoin.Deregister(this, this.OnJoin);
-            Commands.ChatCommands.RemoveAll(c => c.CommandDelegate == this.BetterWhitelistCommand);
         }
 
         base.Dispose(disposing);

--- a/src/CaiCustomEmojiCommand/Plugin.cs
+++ b/src/CaiCustomEmojiCommand/Plugin.cs
@@ -21,6 +21,7 @@ public class CaiCustomEmojiCommand : LazyPlugin
     public override void Initialize()
     {
         GetDataHandlers.Emoji.Register(this.OnGetEmoji);
+        base.Initialize();
     }
 
 

--- a/src/CaiPacketDebug/Plugin.cs
+++ b/src/CaiPacketDebug/Plugin.cs
@@ -36,10 +36,11 @@ public class CaiPacketDebug : LazyPlugin
 
     public override void Initialize()
     {
-        Commands.ChatCommands.Add(new Command("CaiPacketDebug.Use", this.CpdCmd, "cpd"));
+        this.addCommands.Add(new Command("CaiPacketDebug.Use", this.CpdCmd, "cpd"));
         Hooks.MessageBuffer.InvokeGetData += this.MessageBufferOnInvokeGetData;
         Hooks.NetMessage.InvokeSendBytes += this.NetMessageOnInvokeSendBytes;
         NetManager.SendData += this.NetManagerOnSendData;
+        base.Initialize();
     }
     
     protected override void Dispose(bool disposing)
@@ -49,7 +50,6 @@ public class CaiPacketDebug : LazyPlugin
             Hooks.MessageBuffer.InvokeGetData -= this.MessageBufferOnInvokeGetData;
             Hooks.NetMessage.InvokeSendBytes -= this.NetMessageOnInvokeSendBytes;
             NetManager.SendData -= this.NetManagerOnSendData;
-            Commands.ChatCommands.RemoveAll(x => x.CommandDelegate == this.CpdCmd);
         }
 
         base.Dispose(disposing);

--- a/src/Chameleon/Chameleon.cs
+++ b/src/Chameleon/Chameleon.cs
@@ -34,6 +34,7 @@ public class Chameleon : LazyPlugin
     {
         ServerApi.Hooks.NetGetData.Register(this, OnGetData, int.MaxValue);
         ServerApi.Hooks.GamePostInitialize.Register(this, OnPostInit, int.MaxValue);
+        base.Initialize();
 
     }
 

--- a/src/ChattyBridge/Plugin.cs
+++ b/src/ChattyBridge/Plugin.cs
@@ -26,19 +26,17 @@ public class Plugin : LazyPlugin
 
     public override void Initialize()
     {
-        TShock.RestApi.Register("/chat", HandleMsg);
+        this.addRestCommands.Add(new RestCommand("/chat", HandleMsg));
         ServerApi.Hooks.ServerChat.Register(this, this.OnChat);
         ServerApi.Hooks.NetGreetPlayer.Register(this, this.OnGreet);
         ServerApi.Hooks.ServerLeave.Register(this, this.OnLeave);
+        base.Initialize();
     }
 
     protected override void Dispose(bool disposing)
     {
         if (disposing)
         {
-            ((List<RestCommand>) typeof(Rest).GetField("commands", BindingFlags.NonPublic | BindingFlags.Instance)!
-            .GetValue(TShock.RestApi)!)
-            .RemoveAll(x => x.UriTemplate == "/chat");
             ServerApi.Hooks.ServerChat.Deregister(this, this.OnChat);
             ServerApi.Hooks.NetGreetPlayer.Deregister(this, this.OnGreet);
             ServerApi.Hooks.ServerLeave.Deregister(this, this.OnLeave);

--- a/src/CreateSpawn/Plugin.cs
+++ b/src/CreateSpawn/Plugin.cs
@@ -25,6 +25,7 @@ public class CreateSpawn(Main game) : LazyPlugin(game)
         ExtractData();
         ServerApi.Hooks.GamePostInitialize.Register(this, this.GamePost);
         On.Terraria.WorldGen.AddGenerationPass_string_WorldGenLegacyMethod += this.WorldGen_AddGenerationPass_string_WorldGenLegacyMethod;
+        base.Initialize();
     }
 
     private void WorldGen_AddGenerationPass_string_WorldGenLegacyMethod(On.Terraria.WorldGen.orig_AddGenerationPass_string_WorldGenLegacyMethod orig, string name, WorldGenLegacyMethod method)

--- a/src/DonotFuck/DonotFuck.cs
+++ b/src/DonotFuck/DonotFuck.cs
@@ -20,7 +20,8 @@ public class Plugin : LazyPlugin
     public override void Initialize()
     {
         ServerApi.Hooks.ServerChat.Register(this, this.OnChat);
-        TShockAPI.Commands.ChatCommands.Add(new Command("DonotFuck", Commands.DFCmd, "df"));
+        this.addCommands.Add(new Command("DonotFuck", Commands.DFCmd, "df"));
+        base.Initialize();
     }
 
     protected override void Dispose(bool disposing)
@@ -28,7 +29,6 @@ public class Plugin : LazyPlugin
         if (disposing)
         {
             ServerApi.Hooks.ServerChat.Deregister(this, this.OnChat);
-            TShockAPI.Commands.ChatCommands.RemoveAll(x => x.CommandDelegate == Commands.DFCmd);
         }
         base.Dispose(disposing);
     }

--- a/src/Dummy/Plugin.cs
+++ b/src/Dummy/Plugin.cs
@@ -28,7 +28,8 @@ public class Plugin : LazyPlugin
     {
         ServerApi.Hooks.ServerLeave.Register(this, this.OnLeave);
         On.Terraria.Netplay.OpenPort += this.Netplay_OpenPort;
-        Commands.ChatCommands.Add(new("dummy.client.use", CommandAdapter.Adapter, "dummy"));
+        this.addCommands.Add(new("dummy.client.use", CommandAdapter.Adapter, "dummy"));
+        base.Initialize();
     }
 
     protected override void Dispose(bool disposing)
@@ -37,7 +38,6 @@ public class Plugin : LazyPlugin
         {
             ServerApi.Hooks.ServerLeave.Deregister(this, this.OnLeave);
             On.Terraria.Netplay.OpenPort -= this.Netplay_OpenPort;
-            Commands.ChatCommands.RemoveAll(c => c.CommandDelegate == CommandAdapter.Adapter);
         }
         base.Dispose(disposing);
     }

--- a/src/EssentialsPlus/EssentialsPlus.cs
+++ b/src/EssentialsPlus/EssentialsPlus.cs
@@ -56,6 +56,7 @@ public class EssentialsPlus : LazyPlugin
         ServerApi.Hooks.GamePostInitialize.Register(this, this.OnPostInitialize);
         ServerApi.Hooks.NetGetData.Register(this, this.OnGetData);
         ServerApi.Hooks.ServerJoin.Register(this, this.OnJoin);
+        base.Initialize();
     }
 
     private void OnReload(ReloadEventArgs e)

--- a/src/HouseRegion/Plugin.cs
+++ b/src/HouseRegion/Plugin.cs
@@ -74,11 +74,12 @@ public class HousingPlugin : LazyPlugin
     {
         this.RD();
         GetDataHandlers.InitGetDataHandler();//初始化配置值，RH要放在服务器开成后再读不然世界ID读不出
-        Commands.ChatCommands.Add(new Command("house.use", this.HCommands, "house") { HelpText = GetString("输入/house help可以显示与房子相关的操作提示。") });
+        this.addCommands.Add(new Command("house.use", this.HCommands, "house") { HelpText = GetString("输入/house help可以显示与房子相关的操作提示。") });
         ServerApi.Hooks.NetGreetPlayer.Register(this, this.OnGreetPlayer);//玩家进入服务器
         ServerApi.Hooks.ServerLeave.Register(this, this.OnLeave);//玩家退出服务器
         ServerApi.Hooks.GamePostInitialize.Register(this, this.PostInitialize);//地图读入后
         Hooks.MessageBuffer.InvokeGetData += this.MessageBufferOnInvokeGetData;
+        base.Initialize();
     }
 
     private bool MessageBufferOnInvokeGetData(Hooks.MessageBuffer.orig_InvokeGetData orig, MessageBuffer instance, ref byte packetId, ref int readOffset, ref int start, ref int length, ref int messageType, int maxPackets)
@@ -103,7 +104,6 @@ public class HousingPlugin : LazyPlugin
     {
         if (disposing)
         {
-            Commands.ChatCommands.RemoveAll(c => c.CommandDelegate == this.HCommands);
             ServerApi.Hooks.NetGreetPlayer.Deregister(this, this.OnGreetPlayer);//玩家进入服务器
             ServerApi.Hooks.ServerLeave.Deregister(this, this.OnLeave);//玩家退出服务器
             ServerApi.Hooks.GamePostInitialize.Deregister(this, this.PostInitialize);//地图读入后

--- a/src/ItemDecoration/Plugin.cs
+++ b/src/ItemDecoration/Plugin.cs
@@ -32,6 +32,7 @@ public class Plugin : LazyPlugin
     {
         ServerApi.Hooks.ServerChat.Register(this, this.OnServerChat);
         Hooks.MessageBuffer.InvokeGetData += this.MessageBuffer_InvokeGetData;
+        base.Initialize();
     }
     
 

--- a/src/LazyAPI/Cil/CilUtils.cs
+++ b/src/LazyAPI/Cil/CilUtils.cs
@@ -1,0 +1,169 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
+using System.Reflection.Emit;
+using System.Reflection.Metadata;
+
+namespace LazyAPI.Cil;
+
+public static class CilUtils
+{
+    private static OpCode?[]? shortOpCodes;
+    private static OpCode?[]? largeOpCodes;
+    public static OpCode?[] ShortOpCodes
+    {
+        get
+        {
+            if (shortOpCodes is null)
+            {
+                InitOpcodes();
+            }
+            return shortOpCodes;
+        }
+    }
+    public static OpCode?[] LargeOpCodes
+    {
+        get
+        {
+            if (largeOpCodes is null)
+            {
+                InitOpcodes();
+            }
+            return largeOpCodes;
+        }
+    }
+    private static Func<Module, object, object>?[]? shortOpcodeTransformFunc;
+    public static Func<Module, object, object>?[] ShortOpcodeTransformFunc
+    {
+        get
+        {
+            if (shortOpcodeTransformFunc is null)
+            {
+                InitOpcodes();
+            }
+            return shortOpcodeTransformFunc;
+        }
+    }
+    private static Func<Module, object, object>?[]? largeOpcodeTransformFunc;
+    public static Func<Module, object, object>?[] LargeOpcodeTransformFunc
+    {
+        get
+        {
+            if (largeOpcodeTransformFunc is null)
+            {
+                InitOpcodes();
+            }
+            return largeOpcodeTransformFunc;
+        }
+    }
+    [MemberNotNull(nameof(shortOpCodes), nameof(largeOpCodes), nameof(shortOpcodeTransformFunc), nameof(largeOpcodeTransformFunc))]
+    private static void InitOpcodes()
+    {
+        var opcodes = typeof(OpCodes).GetFields().Where(x => x.FieldType == typeof(OpCode)).Select(x => (OpCode) x.GetValue(null)!).ToArray();
+        Array.Sort(opcodes, OpCodeComparer.Instance);
+        var index = Array.FindIndex(opcodes, opcode => opcode.Value < 0);
+        shortOpCodes = new OpCode?[256];
+        largeOpCodes = new OpCode?[opcodes.Where(x => x.Value < 0).Select(x => (byte) (ushort) x.Value).Max() + 1];
+        for (var i = 0; i < index; i++)
+        {
+            shortOpCodes[opcodes[i].Value] = opcodes[i];
+        }
+        for (var i = index; i < opcodes.Length; i++)
+        {
+            largeOpCodes[(byte) (ushort) opcodes[i].Value] = opcodes[i];
+        }
+        shortOpcodeTransformFunc = new Func<Module, object, object>?[shortOpCodes.Length];
+        largeOpcodeTransformFunc = new Func<Module, object, object>?[largeOpCodes.Length];
+        var resolveField = static (Module module, object operand) => module.ResolveField((int) operand)!;
+        var resolveMember = static (Module module, object operand) => module.ResolveMember((int) operand)!;
+        var resolveMethod = static (Module module, object operand) => module.ResolveMethod((int) operand)!;
+        var resolveSignature = static (Module module, object operand) => module.ResolveSignature((int) operand)!;
+        var resolveString = static (Module module, object operand) => module.ResolveString((int) operand)!;
+        var resolveType = static (Module module, object operand) => module.ResolveType((int) operand)!;
+        foreach (var code in new ILOpCode[] { ILOpCode.Ldfld, ILOpCode.Ldflda, ILOpCode.Ldsfld, ILOpCode.Ldsflda })
+        {
+            shortOpcodeTransformFunc[(int) code] = resolveField;
+        }
+        foreach (var code in new ILOpCode[] { ILOpCode.Call, ILOpCode.Callvirt })
+        {
+            shortOpcodeTransformFunc[(int) code] = resolveMethod;
+        }
+    }
+    public static List<Instruction> GetInstructionsFromBytes(byte[] bytes)
+    {
+        var ilByteArray = bytes;
+        var ms = new MemoryStream(ilByteArray);
+        var br = new BinaryReader(ms);
+        var result = new List<Instruction>();
+        while (ms.Position != ms.Length)
+        {
+            var instruction = new Instruction(default, null, (int) ms.Position);
+            var opcodeValue = br.ReadByte();
+            var opcode = opcodeValue == 0xFE ? LargeOpCodes[br.ReadByte()]!.Value : ShortOpCodes[opcodeValue]!.Value;
+            instruction.OpCode = (ILOpCode) opcode.Value;
+            switch (opcode.OperandType)
+            {
+                case OperandType.InlineBrTarget:
+                case OperandType.InlineField:
+                case OperandType.InlineMethod:
+                case OperandType.InlineI:
+                case OperandType.InlineSig:
+                case OperandType.InlineString:
+                case OperandType.InlineTok:
+                case OperandType.InlineType:
+                    instruction.Operand = br.ReadInt32();
+                    break;
+                case OperandType.InlineI8:
+                    instruction.Operand = br.ReadInt64();
+                    break;
+                case OperandType.InlineNone:
+                    break;
+#pragma warning disable CS0618 // 类型或成员已过时
+                case OperandType.InlinePhi:
+                    throw new NotSupportedException(nameof(OperandType.InlinePhi));
+#pragma warning restore CS0618 // 类型或成员已过时
+                case OperandType.InlineR:
+                    instruction.Operand = br.ReadDouble();
+                    break;
+                case OperandType.InlineSwitch:
+                    var count = br.ReadUInt32();
+                    var targets = new int[count];
+                    for (var i = 0; i < count; i++)
+                    {
+                        targets[i] = br.ReadInt32();
+                    }
+                    instruction.Operand = targets;
+                    break;
+                case OperandType.InlineVar:
+                    instruction.Operand = br.ReadUInt16();
+                    break;
+                case OperandType.ShortInlineBrTarget:
+                case OperandType.ShortInlineI:
+                    instruction.Operand = br.ReadSByte();
+                    break;
+                case OperandType.ShortInlineR:
+                    instruction.Operand = br.ReadSingle();
+                    break;
+                case OperandType.ShortInlineVar:
+                    instruction.Operand = br.ReadByte();
+                    break;
+                default:
+                    throw new NotSupportedException(opcode.OperandType.ToString());
+            }
+            result.Add(instruction);
+        }
+        return result;
+    }
+    public static OpCode GetOpCode(ILOpCode code)
+    {
+        return (ushort) code >= 0xFE00 ? LargeOpCodes[(ushort) code - 0xFE00]!.Value : ShortOpCodes[(int) code]!.Value;
+    }
+    private class OpCodeComparer : IComparer<OpCode>
+    {
+        public static OpCodeComparer Instance = new OpCodeComparer();
+        private OpCodeComparer() { }
+        public int Compare(OpCode x, OpCode y)
+        {
+            return ((ushort) x.Value).CompareTo((ushort) y.Value);
+        }
+    }
+}

--- a/src/LazyAPI/Cil/Instruction.cs
+++ b/src/LazyAPI/Cil/Instruction.cs
@@ -1,0 +1,38 @@
+﻿using System.Diagnostics;
+using System.Reflection.Emit;
+using System.Reflection.Metadata;
+
+namespace LazyAPI.Cil;
+
+[DebuggerDisplay("OpCode = {OpCode}, Offset = {Offset}")]
+public class Instruction
+{
+    public ILOpCode OpCode;
+    public object? Operand;
+    public int Offset;
+    public bool IsBranchTarget;
+
+    public Instruction(ILOpCode opCode, object? operand = null)
+    {
+        this.OpCode = opCode;
+        this.Operand = operand;
+    }
+    public Instruction(ILOpCode opCode, object? operand, int offset) : this(opCode, operand)
+    {
+        this.Offset = offset;
+    }
+    public int GetSize()
+    {
+        var opcode = CilUtils.GetOpCode(this.OpCode);
+        var size = opcode.Size;
+        return opcode.OperandType switch
+        {
+            OperandType.InlineSwitch => size + (1 + ((Array) this.Operand!).Length) * 4,
+            OperandType.InlineI8 or OperandType.InlineR => size + 8,
+            OperandType.InlineBrTarget or OperandType.InlineField or OperandType.InlineI or OperandType.InlineMethod or OperandType.InlineString or OperandType.InlineTok or OperandType.InlineType or OperandType.ShortInlineR or OperandType.InlineSig => size + 4,
+            OperandType.InlineVar => size + 2,
+            OperandType.ShortInlineBrTarget or OperandType.ShortInlineI or OperandType.ShortInlineVar => size + 1,
+            _ => size,
+        };
+    }
+}

--- a/src/LazyAPI/Commands/CommandHelper.cs
+++ b/src/LazyAPI/Commands/CommandHelper.cs
@@ -98,18 +98,19 @@ internal static class CommandHelper
     }
 
 
-    internal static string[] Register(Type type)
+    internal static TShockAPI.Command Register(Type type)
     {
         if (!(type.IsAbstract && type.IsSealed))
         {
-            Console.WriteLine($"Command `{type.FullName}` should be static");
+            TShock.Log.ConsoleWarn($"Command `{type.FullName}` should be static");
         }
+
         var names = GetCommandAlias(type).ToArray();
         var tree = BuildTree(type, AliasToString(names));
 
-        TShockAPI.Commands.ChatCommands.Add(new TShockAPI.Command(args => ParseCommand(tree, args),
-            names));
-
-        return names;
+        var cmd = new TShockAPI.Command(args => ParseCommand(tree, args),
+            names);
+        TShockAPI.Commands.ChatCommands.Add(cmd);
+        return cmd;
     }
 }

--- a/src/LazyAPI/ConfigFiles/JsonConfigBase.cs
+++ b/src/LazyAPI/ConfigFiles/JsonConfigBase.cs
@@ -14,6 +14,8 @@ public abstract class JsonConfigBase<T> where T : JsonConfigBase<T>, new()
 
     private static CultureInfo cultureInfo = null!;
 
+    internal static GeneralHooks.ReloadEventD? ReloadEvent { get; set; }
+
     protected virtual string Filename => typeof(T).Namespace ?? typeof(T).Name;
 
     protected virtual void SetDefault()
@@ -89,11 +91,12 @@ public abstract class JsonConfigBase<T> where T : JsonConfigBase<T>, new()
     // .cctor is lazy load
     public static string Load()
     {
-        GeneralHooks.ReloadEvent += args =>
+        ReloadEvent = args =>
         {
             _instance = GetConfig();
             _instance.Reload(args);
         };
+        GeneralHooks.ReloadEvent += ReloadEvent;
         return Instance.Filename;
     }
 

--- a/src/LazyAPI/ConfigFiles/SimpleJsonConfig.cs
+++ b/src/LazyAPI/ConfigFiles/SimpleJsonConfig.cs
@@ -1,0 +1,5 @@
+﻿namespace LazyAPI.ConfigFiles;
+
+internal class SimpleJsonConfig : JsonConfigBase<SimpleJsonConfig>
+{
+}

--- a/src/LazyAPI/Hooks/ActionHook.cs
+++ b/src/LazyAPI/Hooks/ActionHook.cs
@@ -1,0 +1,76 @@
+﻿using LazyAPI.Cil;
+using System.Reflection;
+using System.Reflection.Metadata;
+
+namespace LazyAPI.Hooks;
+
+public sealed class ActionHook : HookBase
+{
+    public Action RegisterAction { get; }
+    public Action? UnregisterAction { get; }
+    private readonly Delegate? delegateeObject;
+    private readonly MethodInfo? removeMethod;
+    internal ActionHook(Action registerMethod, Action unregisterMethod, HookLoadType loadType = HookLoadType.Auto) : base(loadType)
+    {
+        ArgumentNullException.ThrowIfNull(registerMethod);
+        ArgumentNullException.ThrowIfNull(unregisterMethod);
+        this.RegisterAction = registerMethod;
+        this.UnregisterAction = unregisterMethod;
+        this.delegateeObject = null;
+        this.removeMethod = null;
+    }
+    public ActionHook(Action registerAction, HookLoadType loadType = HookLoadType.Auto) : base(loadType)
+    {
+        ArgumentNullException.ThrowIfNull(registerAction);
+        this.RegisterAction = registerAction;
+        var registerMethod = registerAction.Method;
+        var module = registerAction.Method.Module;
+        var bytes = registerMethod.GetMethodBody()!.GetILAsByteArray()!;
+        var instructions = CilUtils.GetInstructionsFromBytes(bytes);
+        var ldftnIns = instructions.Single(x => x.OpCode == ILOpCode.Ldftn);
+        var newobjIns = instructions.Single(x => x.OpCode == ILOpCode.Newobj);
+        if (instructions.IndexOf(ldftnIns) + 1 != instructions.IndexOf(newobjIns))
+        {
+            throw new Exception("MSIL is not [ldftn, newobj]");
+        }
+        var targetOpCode = instructions[instructions.IndexOf(ldftnIns) - 1].OpCode;
+        if (targetOpCode is not ILOpCode.Ldnull or ILOpCode.Ldarg_0)
+        {
+            throw new Exception($"methodName: [{registerMethod.DeclaringType!.FullName}.{registerMethod.Name}] first instruction is not Ldnull or Ldarg_0");
+        }
+        var callIns = instructions.Single(x => x.OpCode == ILOpCode.Call);
+        var callMethod = module.ResolveMethod((int) callIns.Operand!)!;
+        if (!callMethod.Name.StartsWith("add_"))
+        {
+            throw new Exception("methodName is not startwith 'add_'");
+        }
+        if (!callMethod.IsStatic)
+        {
+            throw new Exception("method is not Static");
+        }
+        var removeMethodName = string.Concat("remove_", callMethod.Name.AsSpan("add_".Length));
+        var removeMethod = callMethod.DeclaringType!.GetMethod(removeMethodName) ?? throw new Exception($"can't find remove method '{removeMethodName}'");
+        var ldftnMethod = module.ResolveMethod((int) ldftnIns.Operand!)!;
+        var newobjMethod = module.ResolveMethod((int) newobjIns.Operand!)!;
+        this.delegateeObject = targetOpCode == ILOpCode.Ldnull
+            ? Delegate.CreateDelegate(newobjMethod.DeclaringType!, (MethodInfo)ldftnMethod)
+            : Delegate.CreateDelegate(newobjMethod.DeclaringType!, registerAction.Target, (MethodInfo)ldftnMethod);
+        this.removeMethod = removeMethod;
+    }
+    protected override void DoRegister()
+    {
+        this.RegisterAction();
+    }
+
+    protected override void DoUnregister()
+    {
+        if (this.UnregisterAction is null)
+        {
+            this.removeMethod!.Invoke(null, [this.delegateeObject]);
+        }
+        else
+        {
+            this.UnregisterAction();
+        }
+    }
+}

--- a/src/LazyAPI/Hooks/ActionHook.cs
+++ b/src/LazyAPI/Hooks/ActionHook.cs
@@ -34,9 +34,9 @@ public sealed class ActionHook : HookBase
             throw new Exception("MSIL is not [ldftn, newobj]");
         }
         var targetOpCode = instructions[instructions.IndexOf(ldftnIns) - 1].OpCode;
-        if (targetOpCode is not ILOpCode.Ldnull or ILOpCode.Ldarg_0)
+        if (targetOpCode is not (ILOpCode.Ldnull or ILOpCode.Ldarg_0))
         {
-            throw new Exception($"methodName: [{registerMethod.DeclaringType!.FullName}.{registerMethod.Name}] first instruction is not Ldnull or Ldarg_0");
+            throw new Exception($"methodName: [{registerMethod.DeclaringType!.FullName}.{registerMethod.Name}] first instruction is '{targetOpCode}' not Ldnull or Ldarg_0");
         }
         var callIns = instructions.Single(x => x.OpCode == ILOpCode.Call);
         var callMethod = module.ResolveMethod((int) callIns.Operand!)!;

--- a/src/LazyAPI/Hooks/HandlerListHook.cs
+++ b/src/LazyAPI/Hooks/HandlerListHook.cs
@@ -1,0 +1,23 @@
+﻿using TShockAPI;
+
+namespace LazyAPI.Hooks;
+
+public sealed class HandlerListHook<T> : HookBase where T : EventArgs
+{
+    public HandlerList<T> HandlerList { get; private set; }
+    public HandlerList<T>.HandlerItem HandlerItem { get; private set; }
+    public HandlerListHook(HandlerList<T> handlerList, EventHandler<T> eventHandler, HandlerPriority priority = HandlerPriority.Normal, bool gethandled = false, HookLoadType loadType = HookLoadType.Auto) : base(loadType)
+    {
+        this.HandlerList = handlerList;
+        this.HandlerItem = HandlerList<T>.Create(eventHandler, priority, gethandled);
+    }
+    protected override void DoRegister()
+    {
+        this.HandlerList.Register(this.HandlerItem);
+    }
+
+    protected override void DoUnregister()
+    {
+        this.HandlerList.UnRegister(this.HandlerItem.Handler);
+    }
+}

--- a/src/LazyAPI/Hooks/HookBase.cs
+++ b/src/LazyAPI/Hooks/HookBase.cs
@@ -1,0 +1,33 @@
+﻿namespace LazyAPI.Hooks;
+
+public abstract class HookBase
+{
+    public bool Registered { get; protected set; }
+    public HookLoadType LoadType { get; }
+    protected HookBase(HookLoadType loadType)
+    {
+        this.Registered = false;
+    }
+    public bool Register()
+    {
+        if (!this.Registered)
+        {
+            this.DoRegister();
+            this.Registered = true;
+            return true;
+        }
+        return false;
+    }
+    protected abstract void DoRegister();
+    public bool Unregister()
+    {
+        if (this.Registered)
+        {
+            this.DoUnregister();
+            this.Registered = false;
+            return true;
+        }
+        return false;
+    }
+    protected abstract void DoUnregister();
+}

--- a/src/LazyAPI/Hooks/HookLoadType.cs
+++ b/src/LazyAPI/Hooks/HookLoadType.cs
@@ -1,0 +1,7 @@
+﻿namespace LazyAPI.Hooks;
+
+public enum HookLoadType
+{
+    Manual = 0,
+    Auto = 1
+}

--- a/src/LazyAPI/Hooks/HookUtils.cs
+++ b/src/LazyAPI/Hooks/HookUtils.cs
@@ -1,0 +1,17 @@
+﻿using TerrariaApi.Server;
+using TShockAPI;
+
+namespace LazyAPI.Hooks;
+
+public static class HookUtils
+{
+    public static ServerApiHook<ArgsType> GetHook<ArgsType>(this HandlerCollection<ArgsType> handlerCollection, TerrariaPlugin hookPlugin, HookHandler<ArgsType> hookHandler, HookLoadType loadType = HookLoadType.Auto) where ArgsType : EventArgs
+    {
+        return new ServerApiHook<ArgsType>(hookPlugin, handlerCollection, hookHandler, loadType);
+    }
+
+    public static HandlerListHook<ArgsType> GetHook<ArgsType>(this HandlerList<ArgsType> handlerList, EventHandler<ArgsType> hookHandler, HandlerPriority priority = HandlerPriority.Normal, bool gethandled = false, HookLoadType loadType = HookLoadType.Auto) where ArgsType : EventArgs
+    {
+        return new HandlerListHook<ArgsType>(handlerList, hookHandler, priority, gethandled, loadType);
+    }
+}

--- a/src/LazyAPI/Hooks/ServerApiHook.cs
+++ b/src/LazyAPI/Hooks/ServerApiHook.cs
@@ -1,0 +1,25 @@
+﻿using TerrariaApi.Server;
+
+namespace LazyAPI.Hooks;
+
+public sealed class ServerApiHook<ArgsType> : HookBase where ArgsType : EventArgs
+{
+    public TerrariaPlugin Plugin { get; private set; }
+    public HandlerCollection<ArgsType> Collection { get; private set; }
+    public HookHandler<ArgsType> Handler { get; private set; }
+    public ServerApiHook(TerrariaPlugin plugin, HandlerCollection<ArgsType> collection, HookHandler<ArgsType> handler, HookLoadType loadType = HookLoadType.Auto) : base(loadType)
+    {
+        this.Plugin = plugin;
+        this.Collection = collection;
+        this.Handler = handler;
+    }
+    protected override void DoRegister()
+    {
+        this.Collection.Register(this.Plugin, this.Handler);
+    }
+
+    protected override void DoUnregister()
+    {
+        this.Collection.Deregister(this.Plugin, this.Handler);
+    }
+}

--- a/src/LazyAPI/LazyPlugin.cs
+++ b/src/LazyAPI/LazyPlugin.cs
@@ -40,9 +40,9 @@ public abstract class LazyPlugin : TerrariaPlugin
         {
             TShockAPI.TShock.RestApi.Register(cmd);
         }
-        foreach(var hook in this.addHooks)
+        foreach (var hook in this.addHooks)
         {
-            if(hook.LoadType == HookLoadType.Auto)
+            if (hook.LoadType == HookLoadType.Auto)
             {
                 hook.Register();
             }
@@ -63,17 +63,21 @@ public abstract class LazyPlugin : TerrariaPlugin
     {
         if (disposing)
         {
-            foreach(var handler in this.addReloadEvents)
+            foreach (var handler in this.addReloadEvents)
             {
                 GeneralHooks.ReloadEvent -= handler;
             }
-            foreach(var cmd in this.addCommands)
+            foreach (var cmd in this.addCommands)
             {
-                TShockAPI.Commands.ChatCommands.Remove(cmd);    
+                TShockAPI.Commands.ChatCommands.Remove(cmd);
             }
             foreach (var cmd in this.addRestCommands)
             {
                 Utility.Utils.Unregister(TShockAPI.TShock.RestApi, cmd);
+            }
+            foreach (var hook in this.addHooks)
+            {
+                hook.Unregister();
             }
         }
         base.Dispose(disposing);
@@ -89,7 +93,7 @@ public abstract class LazyPlugin : TerrariaPlugin
             {
                 var method = type.BaseType!.GetMethod(nameof(JsonConfigBase<SimpleJsonConfig>.Load)) ?? throw new MissingMethodException($"method 'Load()' is missing inside the lazy loaded config class '{this.Name}'");
                 var name = method.Invoke(null, Array.Empty<object>());
-                if(type.GetProperty(nameof(JsonConfigBase<SimpleJsonConfig>.ReloadEvent))?.GetValue(null) is GeneralHooks.ReloadEventD reloadEvent)
+                if (type.GetProperty(nameof(JsonConfigBase<SimpleJsonConfig>.ReloadEvent))?.GetValue(null) is GeneralHooks.ReloadEventD reloadEvent)
                 {
                     this.addReloadEvents.Add(reloadEvent);
                 }

--- a/src/LazyAPI/LazyPlugin.cs
+++ b/src/LazyAPI/LazyPlugin.cs
@@ -1,6 +1,7 @@
 using LazyAPI.Attributes;
 using LazyAPI.Commands;
 using LazyAPI.ConfigFiles;
+using LazyAPI.Hooks;
 using LazyAPI.Utility;
 using Rests;
 using System.Reflection;
@@ -15,6 +16,7 @@ public abstract class LazyPlugin : TerrariaPlugin
     private readonly List<GeneralHooks.ReloadEventD> addReloadEvents = new();
     protected readonly List<TShockAPI.Command> addCommands = new();
     protected readonly List<RestCommand> addRestCommands = new();
+    protected readonly List<HookBase> addHooks = new();
     public override string Name
     {
         get
@@ -37,6 +39,13 @@ public abstract class LazyPlugin : TerrariaPlugin
         foreach (var cmd in this.addRestCommands)
         {
             TShockAPI.TShock.RestApi.Register(cmd);
+        }
+        foreach(var hook in this.addHooks)
+        {
+            if(hook.LoadType == HookLoadType.Auto)
+            {
+                hook.Register();
+            }
         }
         this.AutoLoad();
         if (this.restToLoad.Count > 0)

--- a/src/LazyAPI/LazyPlugin.cs
+++ b/src/LazyAPI/LazyPlugin.cs
@@ -26,18 +26,27 @@ public abstract class LazyPlugin : TerrariaPlugin
 
     protected LazyPlugin(Main game) : base(game)
     {
+    }
+
+    public override void Initialize()
+    {
+        foreach (var cmd in this.addCommands)
+        {
+            TShockAPI.Commands.ChatCommands.Add(cmd);
+        }
+        foreach (var cmd in this.addRestCommands)
+        {
+            TShockAPI.TShock.RestApi.Register(cmd);
+        }
         this.AutoLoad();
         if (this.restToLoad.Count > 0)
         {
-            ServerApi.Hooks.GameInitialize.Register(this, args =>
+            foreach (var (type, name) in this.restToLoad.SelectMany(type => type.GetCustomAttributes<RestAttribute>(false).SelectMany(attr => attr.alias).Select(name => (type, name))))
             {
-                foreach (var (type, name) in this.restToLoad.SelectMany(type => type.GetCustomAttributes<RestAttribute>(false).SelectMany(attr => attr.alias).Select(name => (type, name))))
-                {
-                    this.addRestCommands.AddRange(RestHelper.Register(type, name, this));
-                }
+                this.addRestCommands.AddRange(RestHelper.Register(type, name, this));
+            }
 
-                this.restToLoad.Clear();
-            });
+            this.restToLoad.Clear();
         }
     }
 

--- a/src/LazyAPI/PluginContainer.cs
+++ b/src/LazyAPI/PluginContainer.cs
@@ -16,8 +16,16 @@ public class PluginContainer : LazyPlugin
     public override void Initialize()
     {
         ServerApi.Hooks.GamePostUpdate.Register(this, this.PostUpdate);
+        base.Initialize();
     }
-
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            ServerApi.Hooks.GamePostUpdate.Deregister(this, this.PostUpdate);
+        }
+        base.Dispose(disposing);
+    }
     private void PostUpdate(EventArgs _)
     {
         ++TimingUtils.Timer;

--- a/src/LazyAPI/Utility/RestHelper.cs
+++ b/src/LazyAPI/Utility/RestHelper.cs
@@ -42,8 +42,9 @@ public static class RestHelper
         };
     }
 
-    internal static void Register(Type type, string name, LazyPlugin plugin)
+    internal static List<RestCommand> Register(Type type, string name, LazyPlugin plugin)
     {
+        var result = new List<RestCommand>();
         foreach (var method in type.GetMethods(BindingFlags.Static | BindingFlags.Public))
         {
             var parser = ParseCommand(method);
@@ -52,13 +53,16 @@ public static class RestHelper
                 continue;
             }
             var sp = method.GetCustomAttribute<RestPathAttribute>() is RestPathAttribute path ? path.alias : method.Name;
-            TShock.RestApi.Register(new SecureRestCommand($"/{name}/{sp}", parser,
+            var cmd = new SecureRestCommand($"/{name}/{sp}", parser,
                 [
                     .. method.GetCustomAttributes<Permission>().Select(p => p.Name)
 ,
                     .. method.GetCustomAttributes<PermissionsAttribute>().Select(p => p.perm),
-                ]));
+                ]);
+            TShock.RestApi.Register(cmd);
+            result.Add(cmd);
             Console.WriteLine(GetString($"[{plugin.Name}] rest endpoint registered: /{name}/{sp}"));
         }
+        return result;
     }
 }

--- a/src/LazyAPI/Utility/Utils.cs
+++ b/src/LazyAPI/Utility/Utils.cs
@@ -1,10 +1,22 @@
-﻿using System.Reflection;
+﻿using Rests;
+using System.Reflection;
+using System.Reflection.Emit;
 using Terraria;
 
 namespace LazyAPI.Utility;
 
 public static class Utils
 {
+    private readonly static Func<Rest, List<RestCommand>> getRestCommandsFunc;
+    static Utils()
+    {
+        var method = new DynamicMethod("get_commands", typeof(List<RestCommand>), new Type[] { typeof(Rest) });
+        var il = method.GetILGenerator();
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldfld, typeof(Rest).GetField("commands", BindingFlags.NonPublic | BindingFlags.Instance)!);
+        il.Emit(OpCodes.Ret);
+        getRestCommandsFunc = method.CreateDelegate<Func<Rest, List<RestCommand>>>();
+    }
     public static Func<T> Eval<T>(string expression)
     {
         var idx = expression.LastIndexOf('.');
@@ -21,6 +33,10 @@ public static class Utils
         return () => exps1.All(e => e()) && exps2.All(e => !e());
     }
 
+    public static bool Unregister(Rest rest, RestCommand command)
+    {
+        return getRestCommandsFunc(rest).Remove(command);
+    }
     internal static Tuple<int, int>? FindItemRef(object item)
     {
         for (var i = 0; i < Main.maxPlayers; ++i)

--- a/src/LifemaxExtra/PluginContainer.cs
+++ b/src/LifemaxExtra/PluginContainer.cs
@@ -25,11 +25,12 @@ public class LifemaxExtra : LazyPlugin
     {
         GeneralHooks.ReloadEvent += this.ReloadConfig;
         this.SaveMPandHP();
-        Commands.ChatCommands.Add(new Command("lifemaxextra.use", this.HP, "hp"));
-        Commands.ChatCommands.Add(new Command("lifemaxextra.use", this.Mana, "mp"));
+        this.addCommands.Add(new Command("lifemaxextra.use", this.HP, "hp"));
+        this.addCommands.Add(new Command("lifemaxextra.use", this.Mana, "mp"));
         GetDataHandlers.PlayerUpdate += this.OnPlayerUpdate;
         GetDataHandlers.PlayerHP += this.OnHP;
         GetDataHandlers.PlayerMana += this.OnMana;
+        base.Initialize();
     }
 
 
@@ -38,7 +39,6 @@ public class LifemaxExtra : LazyPlugin
         if (disposing)
         {
             GeneralHooks.ReloadEvent -= this.ReloadConfig;
-            Commands.ChatCommands.RemoveAll(x => x.CommandDelegate == this.HP || x.CommandDelegate == this.Mana);
             GetDataHandlers.PlayerUpdate -= this.OnPlayerUpdate;
             GetDataHandlers.PlayerHP -= this.OnHP;
             GetDataHandlers.PlayerMana -= this.OnMana;

--- a/src/ModifyWeapons/ModifyWeapons.cs
+++ b/src/ModifyWeapons/ModifyWeapons.cs
@@ -26,7 +26,8 @@ public class Plugin : LazyPlugin
         ServerApi.Hooks.ServerChat.Register(this, this.OnChat);
         GetDataHandlers.ChestItemChange.Register(this.OnChestItemChange);
         ServerApi.Hooks.NetGreetPlayer.Register(this, this.OnGreetPlayer);
-        TShockAPI.Commands.ChatCommands.Add(new Command("mw.use", Commands.CMD, "mw", "修改武器"));
+        this.addCommands.Add(new Command("mw.use", Commands.CMD, "mw", "修改武器"));
+        base.Initialize();
     }
 
     protected override void Dispose(bool disposing)
@@ -38,7 +39,6 @@ public class Plugin : LazyPlugin
             GetDataHandlers.PlayerUpdate.UnRegister(this.OnPlayerUpdate);
             GetDataHandlers.ChestItemChange.UnRegister(this.OnChestItemChange);
             ServerApi.Hooks.NetGreetPlayer.Deregister(this, this.OnGreetPlayer);
-            TShockAPI.Commands.ChatCommands.RemoveAll(x => x.CommandDelegate == Commands.CMD);
         }
         base.Dispose(disposing);
     }

--- a/src/NoteWall/NoteWall.cs
+++ b/src/NoteWall/NoteWall.cs
@@ -23,20 +23,20 @@ public class NoteWall : LazyPlugin
 
     public override void Initialize()
     {
-        Commands.ChatCommands.Add(new Command("notewall.user.add", this.AddNote, "addnote"));
-        Commands.ChatCommands.Add(new Command("notewall.user.view", this.ViewNote, "viewnote","vinote"));
-        Commands.ChatCommands.Add(new Command("notewall.user.page", this.ViewNotesPage,"notewall"));
-        Commands.ChatCommands.Add(new Command("notewall.user.random", this.RandomNote, "randomnote","rdnote"));
-        Commands.ChatCommands.Add(new Command("notewall.user.update", this.UpdateNote, "updatenote","upnote"));
-        Commands.ChatCommands.Add(new Command("notewall.admin.delete", this.DeleteNote, "deletenote","delnote"));
-        Commands.ChatCommands.Add(new Command("notewall.user.my", this.MyNotes, "mynote"));
+        this.addCommands.Add(new Command("notewall.user.add", this.AddNote, "addnote"));
+        this.addCommands.Add(new Command("notewall.user.view", this.ViewNote, "viewnote","vinote"));
+        this.addCommands.Add(new Command("notewall.user.page", this.ViewNotesPage,"notewall"));
+        this.addCommands.Add(new Command("notewall.user.random", this.RandomNote, "randomnote","rdnote"));
+        this.addCommands.Add(new Command("notewall.user.update", this.UpdateNote, "updatenote","upnote"));
+        this.addCommands.Add(new Command("notewall.admin.delete", this.DeleteNote, "deletenote","delnote"));
+        this.addCommands.Add(new Command("notewall.user.my", this.MyNotes, "mynote"));
+        base.Initialize();
     }
 
     protected override void Dispose(bool disposing)
     {
         if (disposing)
         {
-            Commands.ChatCommands.RemoveAll(x => x.CommandDelegate == this.AddNote || x.CommandDelegate == this.ViewNote || x.CommandDelegate == this.ViewNotesPage || x.CommandDelegate == this.RandomNote || x.CommandDelegate == this.UpdateNote || x.CommandDelegate == this.DeleteNote || x.CommandDelegate == this.MyNotes);
         }
         base.Dispose(disposing);
     }

--- a/src/PlayerRandomSwapper/PlayerRandomSwapper.cs
+++ b/src/PlayerRandomSwapper/PlayerRandomSwapper.cs
@@ -21,9 +21,10 @@ public class PlayerRandomSwapper : LazyPlugin
 
     public override void Initialize()
     {
-        Commands.ChatCommands.Add(new Command("swapplugin.toggle", this.SwapToggle, "swaptoggle", GetString("随机互换")));
+        this.addCommands.Add(new Command("swapplugin.toggle", this.SwapToggle, "swaptoggle", GetString("随机互换")));
         ServerApi.Hooks.GameUpdate.Register(this, this.OnUpdate);
         this.RandomSwapTime();
+        base.Initialize();
     }
 
     protected override void Dispose(bool disposing)
@@ -31,7 +32,6 @@ public class PlayerRandomSwapper : LazyPlugin
         if (disposing)
         {
             ServerApi.Hooks.GameUpdate.Deregister(this, this.OnUpdate);
-            Commands.ChatCommands.RemoveAll(c => c.CommandDelegate == this.SwapToggle);
         }
         base.Dispose(disposing);
     }

--- a/src/PlayerSpeed/PlayerSpeed.cs
+++ b/src/PlayerSpeed/PlayerSpeed.cs
@@ -23,7 +23,8 @@ public class PlayerSpeed : LazyPlugin
         ServerApi.Hooks.NpcKilled.Register(this, this.NpcKilled);
         GetDataHandlers.PlayerUpdate.Register(this.OnPlayerUpdate);
         ServerApi.Hooks.NetGreetPlayer.Register(this, this.OnGreetPlayer);
-        TShockAPI.Commands.ChatCommands.Add(new Command("vel.use", Commands.vel, "vel", "速度"));
+        this.addCommands.Add(new Command("vel.use", Commands.vel, "vel", "速度"));
+        base.Initialize();
     }
 
     protected override void Dispose(bool disposing)
@@ -33,7 +34,6 @@ public class PlayerSpeed : LazyPlugin
             ServerApi.Hooks.NpcKilled.Deregister(this, this.NpcKilled);
             GetDataHandlers.PlayerUpdate.UnRegister(this.OnPlayerUpdate);
             ServerApi.Hooks.NetGreetPlayer.Deregister(this, this.OnGreetPlayer);
-            TShockAPI.Commands.ChatCommands.RemoveAll(x => x.CommandDelegate == Commands.vel);
         }
         base.Dispose(disposing);
     }

--- a/src/ProgressBag/Plugin.cs
+++ b/src/ProgressBag/Plugin.cs
@@ -22,13 +22,14 @@ public class Plugin : LazyPlugin
     }
     public override void Initialize()
     {
-        Commands.ChatCommands.Add(new Command("bag.use", this.GiftBag, "礼包", "bag"));
+        this.addCommands.Add(new Command("bag.use", this.GiftBag, "礼包", "bag"));
+        base.Initialize();
     }
     protected override void Dispose(bool disposing)
     {
         if (disposing)
         {
-            Commands.ChatCommands.RemoveAll(f => f.CommandDelegate == this.GiftBag);
+            
         }
         base.Dispose(disposing);
     }

--- a/src/QRCoder/QRCoder.cs
+++ b/src/QRCoder/QRCoder.cs
@@ -25,38 +25,32 @@ public class QRCoder(Main game) : LazyPlugin(game)
 
     public override void Initialize()
     {
-        Commands.ChatCommands.Add(new ("qr.add", this.QREncoder, "qr")
+        this.addCommands.Add(new ("qr.add", this.QREncoder, "qr")
         {
             HelpText = GetString("生成二维码，用法：/qr <内容> [尺寸(不指定则为自适应)]")
         });
 
-        Commands.ChatCommands.Add(new ("qr.add", this.SetQRPosition, "qrpos")
+        this.addCommands.Add(new ("qr.add", this.SetQRPosition, "qrpos")
         {
             HelpText = GetString("设置二维码位置，用法：/qrpos <tl|bl|tr|br>，tl=左上角，bl=左下角，tr=右上角，br=右下角")
         });
 
-        Commands.ChatCommands.Add(new ("qr.add", this.SetQRConfig, "qrconf")
+        this.addCommands.Add(new ("qr.add", this.SetQRConfig, "qrconf")
         {
             HelpText = GetString("设置二维码配置内容，用法：/qrconf <键> <值>")
         });
 
         TileEdit += this.OnTileEdit;
         AppDomain.CurrentDomain.AssemblyResolve += this.CurrentDomain_AssemblyResolve;
-        TShock.RestApi.Register(new SecureRestCommand("/tool/qrcoder", this.QRtest, "tool.rest.qrcoder"));
+        this.addRestCommands.Add(new SecureRestCommand("/tool/qrcoder", this.QRtest, "tool.rest.qrcoder"));
+        base.Initialize();
     }
     protected override void Dispose(bool Disposing)
     {
         if (Disposing)
         {
-            Commands.ChatCommands.RemoveAll(c => c.CommandDelegate == this.QREncoder);
-            Commands.ChatCommands.RemoveAll(c => c.CommandDelegate == this.SetQRPosition);
-            Commands.ChatCommands.RemoveAll(c => c.CommandDelegate == this.SetQRConfig);
             AppDomain.CurrentDomain.AssemblyResolve -= this.CurrentDomain_AssemblyResolve;
             TileEdit -= this.OnTileEdit;
-            ((List<RestCommand>) typeof(Rest)
-                .GetField("commands", BindingFlags.NonPublic | BindingFlags.Instance)!
-                .GetValue(TShock.RestApi)!)
-                .RemoveAll(x => x.UriTemplate == "/tool/qrcoder");
         }
         base.Dispose(Disposing);
     }

--- a/src/ServerTools/Plugin.cs
+++ b/src/ServerTools/Plugin.cs
@@ -49,6 +49,7 @@ public partial class Plugin : LazyPlugin
         OnTimer += this.OnUpdatePlayerOnline;
         On.OTAPI.Hooks.MessageBuffer.InvokeGetData += this.MessageBuffer_InvokeGetData;
         HandleCommandLine(Environment.GetCommandLineArgs());
+        base.Initialize();
     }
 
     protected override void Dispose(bool disposing)

--- a/src/SurfaceBlock/SurfaceBlock.cs
+++ b/src/SurfaceBlock/SurfaceBlock.cs
@@ -23,6 +23,7 @@ public class SurfaceBlock : LazyPlugin
         GetDataHandlers.NewProjectile += this.ProjectNew!;
         GetDataHandlers.PlayerUpdate += this.OnPlayerUpdate!;
         ServerApi.Hooks.NetGreetPlayer.Register(this, this.OnGreetPlayer);
+        base.Initialize();
     }
 
     protected override void Dispose(bool disposing)


### PR DESCRIPTION
添加类型: ActionHook，HandlerListHook<T>，ServerApiHook<T>
LazyPlugin: 添加了addCommands，addRestCommands， addHooks和内部使用的addReloadEvents以提供自动卸载功能。移动构造的内容到Initialize()以解决某些bug，修改子类的Initialize()以匹配更改，并把ChatCommands.Add()和RestApi.Register()全部移动到addCommands和addRestCommands
修改了两个子类的Initialize()以展示Hook如何使用