### PR TITLE
BanNpc：新增Boss全局多段滑动窗口速率限制功能

### DIFF
--- a/src/BanNpc/Config.cs
+++ b/src/BanNpc/Config.cs
@@ -1,15 +1,32 @@
 ﻿using LazyAPI.Attributes;
 using LazyAPI.ConfigFiles;
-namespace BanNpc;
+using LazyAPI;
+using System.Collections.Generic;
 
+namespace BanNpc;
 
 [Config]
 public class Config : JsonConfigBase<Config>
 {
     protected override string Filename => "BanNpc";
 
-    [LocalizedPropertyName(CultureType.Chinese, "阻止怪物生成表")]
-    [LocalizedPropertyName(CultureType.English, "BanNpcs")]
-    public HashSet<int> Npcs { get; set; } = new();
+    public HashSet<int> BanNpcs { get; set; } = new HashSet<int>();
 
+    public List<BossRateConfig> BossRateLimitList { get; set; } = new List<BossRateConfig>();
+}
+
+public class BossRateConfig
+{
+    public int NpcId { get; set; }
+    public int PlayerCooldownSeconds { get; set; } = 0;
+    public int GlobalMaxAlive { get; set; } = 2;
+    public string DenyMessage { get; set; } = "召唤过于频繁";
+    public bool BroadcastDeny { get; set; } = false;
+    public List<RateWindow> RateWindows { get; set; } = new List<RateWindow>();
+}
+
+public class RateWindow
+{
+    public int WindowSeconds { get; set; }
+    public int MaxCount { get; set; }
 }

--- a/src/BanNpc/Plugin.cs
+++ b/src/BanNpc/Plugin.cs
@@ -2,22 +2,33 @@
 using Terraria;
 using TerrariaApi.Server;
 using TShockAPI;
+using TShockAPI.Hooks;
+using System;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace BanNpc;
 
 [ApiVersion(2, 1)]
 public class Plugin : LazyPlugin
 {
-    public override string Author => "Patrikk,GK 改良";
-
-    public override string Description => GetString("禁止指定怪物的出没");
-
+    public override string Author => "Patrikk,GK 改良 + 唉唉有更新Boss全局分段滑动窗口限流";
+    public override string Description => GetString("禁止指定怪物的出没 + NPC全局分段滑动窗口限流");
     public override string Name => System.Reflection.Assembly.GetExecutingAssembly().GetName().Name!;
-    public override Version Version => new Version(1, 0, 0, 7);
+    public override Version Version => new Version(1, 0, 0, 13);
+
+    /// <summary>全局召唤时间记录：NpcId → 该NPC成功召唤的时间戳列表</summary>
+    private Dictionary<int, List<DateTime>> _globalSpawnRecords = new Dictionary<int, List<DateTime>>();
+    /// <summary>NpcId → 强制锁死到期时间；DateTime.MinValue代表无锁</summary>
+    private Dictionary<int, DateTime> _bossLockUntil = new Dictionary<int, DateTime>();
+    /// <summary>NpcId → 上一次广播提示时间，用于防抖防刷屏</summary>
+    private Dictionary<int, DateTime> _lastBroadcastTime = new Dictionary<int, DateTime>();
+
+    /// <summary>同个Boss限流提示最小广播间隔(秒)</summary>
+    private const int BroadcastCooldownSec = 15;
 
     public Plugin(Main game) : base(game)
     {
-
     }
 
     public override void Initialize()
@@ -25,121 +36,271 @@ public class Plugin : LazyPlugin
         Commands.ChatCommands.Add(new Command("bannpc.use", this.BanCommand, "bm"));
         ServerApi.Hooks.NpcSpawn.Register(this, this.OnSpawn);
         ServerApi.Hooks.NpcTransform.Register(this, this.OnTransform);
+        GeneralHooks.ReloadEvent += OnTShockReload;
     }
+
     protected override void Dispose(bool disposing)
     {
         if (disposing)
         {
-            Commands.ChatCommands.RemoveAll(x => x.CommandDelegate == this.BanCommand);
-            ServerApi.Hooks.NpcSpawn.Deregister(this, this.OnSpawn);
-            ServerApi.Hooks.NpcTransform.Deregister(this, this.OnTransform);
-        }
+            Commands.ChatCommands.RemoveAll(x => x.CommandDelegate == BanCommand);
+            ServerApi.Hooks.NpcSpawn.Deregister(this, OnSpawn);
+            ServerApi.Hooks.NpcTransform.Deregister(this, OnTransform);
+            GeneralHooks.ReloadEvent -= OnTShockReload;
 
-        // Call the base class dispose method.
+            _globalSpawnRecords.Clear();
+            _bossLockUntil.Clear();
+            _lastBroadcastTime.Clear();
+        }
         base.Dispose(disposing);
+    }
+
+    private void OnTShockReload(ReloadEventArgs args)
+    {
+        _globalSpawnRecords.Clear();
+        _bossLockUntil.Clear();
+        _lastBroadcastTime.Clear();
+        TShock.Log.ConsoleInfo("[BanNpc] /reload 已清空全部NPC召唤记录、锁状态、广播防抖状态");
     }
 
     private void BanCommand(CommandArgs args)
     {
-
         if (args.Parameters.Count == 1 && args.Parameters[0].ToLower() == "list")
         {
-            if (Config.Instance.Npcs.Count < 1)
+            if (Config.Instance.BanNpcs.Count < 1)
             {
                 args.Player.SendInfoMessage(GetString("当前阻止表为空."));
             }
             else
             {
-                args.Player.SendInfoMessage(GetString("阻止怪物表: ") + string.Join(", ", Config.Instance.Npcs.Select(x => TShock.Utils.GetNPCById(x)?.FullName + "({0})".SFormat(x))));
+                args.Player.SendInfoMessage(GetString("阻止怪物表: ") + string.Join(", ", Config.Instance.BanNpcs.Select(x => TShock.Utils.GetNPCById(x)?.FullName + $"({x})")));
             }
 
+            if (Config.Instance.BossRateLimitList.Any())
+            {
+                var rateText = string.Join(", ", Config.Instance.BossRateLimitList.Select(cfg =>
+                {
+                    var windows = string.Join(" | ", cfg.RateWindows.Select(w => $"{w.WindowSeconds}s:{w.MaxCount}次"));
+                    return $"{TShock.Utils.GetNPCById(cfg.NpcId)?.FullName}({cfg.NpcId}) 窗口[{windows}] 存活上限:{cfg.GlobalMaxAlive} 广播:{cfg.BroadcastDeny}";
+                }));
+                args.Player.SendInfoMessage($"[速率限制配置]: {rateText}");
+            }
+            else
+            {
+                args.Player.SendInfoMessage("[速率限制配置]: 为空");
+            }
             return;
         }
         else if (args.Parameters.Count == 2)
         {
-            NPC npc;
             var matchedNPCs = TShock.Utils.GetNPCByIdOrName(args.Parameters[1]);
             if (matchedNPCs.Count == 0)
             {
                 args.Player.SendErrorMessage(GetString("无效NPC: {0} !"), args.Parameters[1]);
                 return;
             }
-            else if (matchedNPCs.Count > 1)
+            if (matchedNPCs.Count > 1)
             {
                 args.Player.SendMultipleMatchError(matchedNPCs.Select(i => i.FullName));
                 return;
             }
-            else
-            {
-                npc = matchedNPCs[0];
-            }
+            NPC npc = matchedNPCs[0];
+
             switch (args.Parameters[0].ToLower())
             {
                 case "add":
-                {
-                    if (Config.Instance.Npcs.Contains(npc.netID))
                     {
-                        args.Player.SendErrorMessage(GetString("NPC ID {0} 已在阻止列表中!"), npc.netID);
-                        return;
+                        if (Config.Instance.BanNpcs.Contains(npc.netID))
+                        {
+                            args.Player.SendErrorMessage(GetString("NPC ID {0} 已在阻止列表!"), npc.netID);
+                            return;
+                        }
+                        Config.Instance.BanNpcs.Add(npc.netID);
+                        Config.Save();
+                        args.Player.SendSuccessMessage(GetString("已添加NPC ID {0}到阻止列表"), npc.netID);
+                        break;
                     }
-                    Config.Instance.Npcs.Add(npc.netID);
-                    Config.Save();
-                    args.Player.SendSuccessMessage(GetString("已成功将NPC ID添加到阻止列表: {0}!"), npc.netID);
-                    break;
-                }
                 case "delete":
                 case "del":
                 case "remove":
-                {
-                    if (!Config.Instance.Npcs.Contains(npc.netID))
                     {
-                        args.Player.SendErrorMessage(GetString("NPC ID {0} 不在筛选列表中!"), npc.netID);
-                        return;
+                        if (!Config.Instance.BanNpcs.Contains(npc.netID))
+                        {
+                            args.Player.SendErrorMessage(GetString("NPC ID {0} 不在阻止列表!"), npc.netID);
+                            return;
+                        }
+                        Config.Instance.BanNpcs.Remove(npc.netID);
+                        Config.Save();
+                        args.Player.SendSuccessMessage(GetString("已从阻止列表删除NPC ID {0}"), npc.netID);
+                        break;
                     }
-                    Config.Instance.Npcs.Remove(npc.netID);
-                    Config.Save();
-                    args.Player.SendSuccessMessage(GetString("已成功从阻止列表中删除NPC ID: {0}!"), npc.netID);
-                    break;
-                }
                 default:
-                {
-                    args.Player.SendErrorMessage(GetString("语法错误: /bm <add/del> [名称 或 ID]"));
+                    args.Player.SendErrorMessage(GetString("语法错误：/bm <add/del> [NPC名称或ID]"));
                     break;
-                }
             }
         }
         else
         {
-            args.Player.SendInfoMessage("/bm");
             args.Player.SendInfoMessage("/bm list");
-            args.Player.SendInfoMessage(GetString("/bm add [名称 或 ID]"));
-            args.Player.SendInfoMessage(GetString("/bm del [名称 或 ID]"));
-            return;
+            args.Player.SendInfoMessage("/bm add [NPC名称或ID]");
+            args.Player.SendInfoMessage("/bm del [NPC名称或ID]");
         }
     }
+
     private void OnTransform(NpcTransformationEventArgs args)
     {
-        if (args.Handled)
+        if (args.Handled) return;
+        var targetNpc = Main.npc[args.NpcId];
+        if (Config.Instance.BanNpcs.Contains(targetNpc.netID))
         {
-            return;
-        }
-
-        if (Config.Instance.Npcs.Contains(Main.npc[args.NpcId].netID))
-        {
-            Main.npc[args.NpcId].active = false;
+            targetNpc.active = false;
         }
     }
+
     private void OnSpawn(NpcSpawnEventArgs args)
     {
-        if (args.Handled)
+        if (args.Handled) return;
+        var npc = Main.npc[args.NpcId];
+        int npcId = npc.netID;
+
+        //黑名单优先拦截
+        if (Config.Instance.BanNpcs.Contains(npcId))
         {
+            args.Handled = true;
+            npc.active = false;
             return;
         }
 
-        if (Config.Instance.Npcs.Contains(Main.npc[args.NpcId].netID))
+        var rateCfg = Config.Instance.BossRateLimitList.FirstOrDefault(c => c.NpcId == npcId);
+        if (rateCfg is null)
+            return;
+
+        DateTime now = DateTime.Now;
+
+        if (!_bossLockUntil.ContainsKey(npcId))
+            _bossLockUntil[npcId] = DateTime.MinValue;
+        if (!_lastBroadcastTime.ContainsKey(npcId))
+            _lastBroadcastTime[npcId] = DateTime.MinValue;
+        if (!_globalSpawnRecords.ContainsKey(npcId))
+            _globalSpawnRecords[npcId] = new List<DateTime>();
+
+        var lockEnd = _bossLockUntil[npcId];
+        var lastBroadcast = _lastBroadcastTime[npcId];
+        var timeList = _globalSpawnRecords[npcId];
+
+        // BroadcastDeny配置生效：true=开启防抖广播，false=静默拦截
+        bool needBroadcast = rateCfg.BroadcastDeny && ((now - lastBroadcast).TotalSeconds > BroadcastCooldownSec);
+
+        // 当前处于强制锁死状态，直接拦截（锁死状态不输出窗口信息，只输出基础提示）
+        if (lockEnd > now)
         {
             args.Handled = true;
-            Main.npc[args.NpcId].active = false;
+            npc.active = false;
+            if (needBroadcast)
+            {
+                TShock.Utils.Broadcast(rateCfg.DenyMessage, Microsoft.Xna.Framework.Color.OrangeRed);
+                _lastBroadcastTime[npcId] = now;
+            }
+            return;
+        }
+
+        bool isTriggerLimit = false;
+        int triggerWindowSec = 0;
+        int triggerWindowMaxCount = 0;
+        int remainSec = 0;
+
+        if (rateCfg.RateWindows.Any())
+        {
+            //清理掉所有超出最大窗口时长的过期时间戳
+            var maxWindow = rateCfg.RateWindows.Max(w => w.WindowSeconds);
+            var expireTime = now.AddSeconds(-maxWindow);
+            timeList.RemoveAll(t => t < expireTime);
+
+            //锁刚刚到期，本次成功召唤，重置锁状态，清空历史时间
+            bool isLockJustExpired = lockEnd <= now && _bossLockUntil[npcId] != DateTime.MinValue;
+            if (isLockJustExpired)
+            {
+                timeList.Clear();
+                _bossLockUntil[npcId] = DateTime.MinValue;
+            }
+
+            foreach (var win in rateCfg.RateWindows)
+            {
+                var cutOff = now.AddSeconds(-win.WindowSeconds);
+                int count = timeList.Count(t => t >= cutOff);
+                if (count >= win.MaxCount)
+                {
+                    isTriggerLimit = true;
+                    triggerWindowSec = win.WindowSeconds;
+                    triggerWindowMaxCount = win.MaxCount;
+                    break;
+                }
+            }
+
+            if (isTriggerLimit)
+            {
+                //触发超限，设置强制锁死
+                _bossLockUntil[npcId] = now.AddSeconds(triggerWindowSec);
+                args.Handled = true;
+                npc.active = false;
+                if (needBroadcast)
+                {
+                    string finalMsg = $"{rateCfg.DenyMessage} (限制：{triggerWindowSec}s/{triggerWindowMaxCount}次)";
+                    TShock.Utils.Broadcast(finalMsg, Microsoft.Xna.Framework.Color.OrangeRed);
+                    _lastBroadcastTime[npcId] = now;
+                }
+                return;
+            }
+
+            //放行：追加本次成功召唤时间戳，不再无脑清空全部列表
+            timeList.Add(now);
+        }
+        else if (rateCfg.PlayerCooldownSeconds > 0)
+        {
+            //简单冷却模式，无强制锁死
+            var cutOff = now.AddSeconds(-rateCfg.PlayerCooldownSeconds);
+            var lastSpawn = timeList.Where(t => t >= cutOff).OrderByDescending(t => t).FirstOrDefault();
+            if (lastSpawn != default)
+            {
+                remainSec = (int)(lastSpawn.AddSeconds(rateCfg.PlayerCooldownSeconds) - now).TotalSeconds;
+                if (remainSec < 0) remainSec = 0;
+
+                args.Handled = true;
+                npc.active = false;
+                if (needBroadcast)
+                {
+                    string msg = $"{rateCfg.DenyMessage} 请在 {remainSec} 秒后再尝试！";
+                    TShock.Utils.Broadcast(msg, Microsoft.Xna.Framework.Color.OrangeRed);
+                    _lastBroadcastTime[npcId] = now;
+                }
+                return;
+            }
+            timeList.Add(now);
+        }
+
+        //存活上限校验
+        if (rateCfg.GlobalMaxAlive > 0)
+        {
+            int aliveCount = 0;
+            for (int i = 0; i < Main.npc.Length; i++)
+            {
+                var checkNpc = Main.npc[i];
+                if (checkNpc.active && checkNpc.netID == rateCfg.NpcId)
+                {
+                    aliveCount++;
+                }
+            }
+            if (aliveCount > rateCfg.GlobalMaxAlive)
+            {
+                args.Handled = true;
+                npc.active = false;
+                if (needBroadcast)
+                {
+                    TShock.Utils.Broadcast("该Boss当前存活数量已达上限！", Microsoft.Xna.Framework.Color.OrangeRed);
+                    _lastBroadcastTime[npcId] = now;
+                }
+                return;
+            }
         }
     }
 }

--- a/src/BanNpc/README.md
+++ b/src/BanNpc/README.md
@@ -1,7 +1,9 @@
 # BanNpc 阻止怪物生成
 
-- 作者: GK
+- 作者: GK，唉唉有新增 Boss 全局滑动窗口速率限制功能
 - 出处: GK
+
+**扩展功能：Boss 全局滑动窗口限流**：针对指定 Boss NPC，配置多段时间窗口召唤次数阈值；任意窗口触发阈值后，全局锁死该 Boss 召唤，锁死冷却结束后重新开始统计；仅拦截玩家发起的 Boss 召唤，雕像、其他插件生成的 NPC 不做拦截。
 
 ## 指令
 
@@ -15,13 +17,29 @@
 > 配置文件位置：tshock/BanNPC.zh-CN.json
 ```json5
 {
-  "阻止怪物生成表": []
+  "阻止怪物生成表": [],
+  "Boss速率限制配置": [
+    {
+      "NpcId": 146,//需要限流的 Boss NPC ID
+      "PlayerCooldownSeconds": 0,
+      "GlobalMaxAlive": 2,//该 Boss 同时存活最大数量，超出阻止召唤
+      "DenyMessage": "召唤过于频繁，已暂时封禁，请稍后再尝试！",//触发限流时发送的提示文本
+      "BroadcastDeny": true,
+      "RateWindows": [
+        {"WindowSeconds":60,"MaxCount":30},//`WindowSeconds`窗口时长 (秒)`MaxCount`该窗口内允许最大召唤次数
+        {"WindowSeconds":300,"MaxCount":180}
+      ]
+    }
+  ]
 }
+
 ```
 
 ## 更新日志
 
-
+### v1.0.0.5
+- 新增 Boss 全局多段滑动窗口速率限制；触发阈值全局锁死 Boss 召唤；成功召唤才计入统计；区分玩家召唤与其他来源生成
+- 
 ### v1.0.0.4
 - 准备更新TS 5.2.1
 - 修正文档


### PR DESCRIPTION
## 改动说明
1. BanNpc插件新增 **Boss全局多段滑动窗口速率限制**，管控Boss召唤频率，防止短时间大量刷Boss。
2. 修改 `src/BanNpc/Config.cs`：增加滑动窗口限流相关配置项。
"BossRateLimitList": [
    {
      "NpcId": 134,
  "PlayerCooldownSeconds": 0,
  "GlobalMaxAlive": 2,
  "DenyMessage": "[I:556]Boss召唤过于频繁，已暂时绝种！",
  "BroadcastDeny": true,
  "RateWindows": [
    {"WindowSeconds": 60,"MaxCount": 30},
    {"WindowSeconds": 300,"MaxCount": 130},
    {"WindowSeconds": 600,"MaxCount": 220},
    {"WindowSeconds": 1800,"MaxCount": 400},
    {"WindowSeconds": 3600,"MaxCount": 500},
    {"WindowSeconds": 5400,"MaxCount": 500}
      ]
    }
  ]
}
4. 修改 `src/BanNpc/Plugin.cs`：实现多段滑动窗口限流业务逻辑。

## Sourcery 摘要

在保留 BanNpc 现有 NPC 阻止和管理功能的同时，新增可配置的全局 Boss 召唤速率限制。

新功能：
- 为选定的 Boss NPC 召唤添加可配置的全局、多时间窗口滑动速率限制，包括玩家冷却时间、存活数量上限、拒绝消息和可选广播。

错误修复：
- 保留现有的 NPC 阻止行为，并在处理 Boss 速率限制前优先执行黑名单检查。

增强功能：
- 按 Boss 跟踪召唤历史、锁定状态和广播冷却时间；在 TShock 重新加载时重置运行时状态，并通过现有的列表命令公开速率限制设置。

文档：
- 记录 Boss 全局滑动窗口速率限制、配置选项及其召唤来源行为。

杂项：
- 更新 BanNpc 的元数据和版本信息，以支持扩展后的功能。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add configurable global Boss summon rate limiting while retaining BanNpc's existing NPC blocking and management features.

New Features:
- Add configurable global, multi-window sliding-rate limits for selected Boss NPC summons, including per-player cooldowns, alive-count caps, denial messages, and optional broadcasts.

Bug Fixes:
- Preserve existing NPC blocking behavior while prioritizing blacklist checks over Boss rate-limit handling.

Enhancements:
- Track summon history, lockout state, and broadcast cooldowns per Boss, reset runtime state on TShock reload, and expose rate-limit settings through the existing list command.

Documentation:
- Document Boss global sliding-window rate limiting, configuration options, and its summon-source behavior.

Chores:
- Update BanNpc metadata and version information for the expanded functionality.

</details>